### PR TITLE
errors: improve frontend handling of errors

### DIFF
--- a/src/lib/DepositController.js
+++ b/src/lib/DepositController.js
@@ -8,7 +8,7 @@
 // Drives the business logic of the InvenioFormApp.
 // Defines what happens when a button is clicked.
 
-import { setFormErrorsFromResponse } from './state/actions';
+import { setFormErrors } from './state/actions';
 import {
   CREATE_DEPOSIT_SUCCESS,
   PUBLISH_SUCCESS,
@@ -79,7 +79,7 @@ export class DepositController {
       const recordURL = response.data.links.self_html;
       window.location.replace(recordURL);
     } catch (error) {
-      store.dispatch(setFormErrorsFromResponse(error, formik));
+      store.dispatch(setFormErrors(error, formik, record));
     }
   }
 

--- a/src/lib/DepositErrorHandler.js
+++ b/src/lib/DepositErrorHandler.js
@@ -9,9 +9,9 @@ import _join from 'lodash/join';
 import _get from 'lodash/get';
 
 export class DepositErrorHandler {
-  extractErrors(response) {
-    const backendErrors = _get(response, 'response.data.errors', []);
-    const backendErrorMessage = _get(response, 'response.data.message', '');
+  extractErrors(error, record) {
+    const backendErrors = _get(error, 'response.data.errors', []);
+    const backendErrorMessage = _get(error, 'response.data.message', '');
     let frontendErrors = { message: backendErrorMessage };
     for (const fieldError of backendErrors) {
       const errorPath = _join([...fieldError.parents, fieldError.field], '.');

--- a/src/lib/DepositRecordSerializer.js
+++ b/src/lib/DepositRecordSerializer.js
@@ -5,6 +5,7 @@
 // React-Invenio-Deposit is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
 
+import _get from 'lodash/get';
 import _isNumber from 'lodash/isNumber';
 import _isEmpty from 'lodash/isEmpty';
 import _isEqual from 'lodash/isEqual';
@@ -55,7 +56,7 @@ export class DepositRecordSerializer {
    * @returns {object} record - with creators in API format
    */
   serializeCreators(record) {
-    const in_creators = record.creators || [];
+    const in_creators = _get(record, 'metadata.creators', []);
     const creators = in_creators.map((creator) => {
       const in_identifiers = creator.identifiers || [];
       const identifiers = in_identifiers.reduce((acc, identifier) => {
@@ -70,13 +71,13 @@ export class DepositRecordSerializer {
 
   /**
    * Transform frontend contributors structure to API-compatible structure.
+   * Strips it out if only default type is there.
    * @method
    * @param {object} record - with contributors in frontend format
    * @returns {object} record - with contributors in API format
    */
   serializeContributors(record) {
-    const in_contributors = record.contributors || [];
-
+    const in_contributors = _get(record, 'metadata.contributors', []);
     // Remove contributors with only a type
     // Note: we have to do this because type is filled by default, but
     // contributors is an optional field
@@ -103,7 +104,7 @@ export class DepositRecordSerializer {
     if (!_isEqual(contributors, in_contributors)) {
       if (contributors.length === 0) {
         // Yes and now it is empty so we need to strip it
-        delete record.contributors;
+        delete record.metadata.contributors;
         return record;
       } else {
         // Yes and we simply restructured the identifiers
@@ -124,37 +125,85 @@ export class DepositRecordSerializer {
    *       complicated, we can create a serialization schema with Yup.
    */
   serialize(record) {
-    let stripped_record = this.removeEmptyValues(record);
-    let serialized_record = this.serializeCreators(stripped_record);
-    serialized_record = this.serializeContributors(serialized_record);
+    let strippedRecord = this.removeEmptyValues(record);
+    let serializedRecord = this.serializeCreators(strippedRecord);
+    serializedRecord = this.serializeContributors(serializedRecord);
 
-    var todayStr = new Date().toISOString();
-    var defaultPublicationDate = todayStr.slice(0, todayStr.indexOf('T'));
+    // Temporary injection of fields not covered by frontend but needed by
+    // backend. As the fields get covered by frontend, remove them from here.
+    // TODO: Remove when fields are implemented
+    serializedRecord = this.fillAccess(serializedRecord);
+    serializedRecord = this.fillPublicationDate(serializedRecord);
+    serializedRecord = this.fillIdentifiers(serializedRecord);
+    serializedRecord = this.fillDescriptions(serializedRecord);
 
-    // TODO: Remove when fields are implemented and
-    // we use deposit backend API
-    let _missingRecordFields = {
-      _access: {
-        metadata_restricted: false,
-        files_restricted: false,
-      },
-      _owners: [1],
-      _created_by: 1,
-      // TODO: Remove these when fields are implemented
-      // also these fields are making the record landing page
-      // to fail if they don't exist
-      identifiers: {
-        DOI: '10.9999/rdm.9999999',
-      },
-      descriptions: [
-        {
-          description: 'Remove me',
-          lang: 'eng',
-          type: 'Abstract',
-        },
-      ],
-      publication_date: defaultPublicationDate,
+    return serializedRecord;
+  }
+
+  /**
+   * Temporarily fill access field until frontend does it.
+   * @method
+   * @param {object} record - in frontend format
+   * @returns {object} record - in API format
+   */
+  fillAccess(record) {
+    let access = {
+      metadata_restricted: false,
+      files_restricted: false,
+      owners: [1],
+      created_by: 1,
+      access_right: _get(record, 'access.access_right', ''),
     };
-    return { ...serialized_record, ..._missingRecordFields };
+
+    return { ...record, access };
+  }
+
+  /**
+   * Temporarily fill publication date field until frontend does it.
+   * @method
+   * @param {object} record - in frontend format
+   * @returns {object} record - in API format
+   */
+  fillPublicationDate(record) {
+    var todayStr = new Date().toISOString();
+    let publication_date = // Using backend naming convention
+      record.metadata.publication_date ||
+      todayStr.slice(0, todayStr.indexOf('T'));
+    let metadata = { ...record['metadata'], publication_date };
+    return { ...record, metadata };
+  }
+
+  /**
+   * Temporarily fill identifiers field until frontend does it.
+   * @method
+   * @param {object} record - in frontend format
+   * @returns {object} record - in API format
+   */
+  fillIdentifiers(record) {
+    let identifiers = {
+      DOI: '10.9999/rdm.9999999',
+    };
+    let metadata = { ...record['metadata'], identifiers };
+
+    return { ...record, metadata };
+  }
+
+  /**
+   * Temporarily fill descriptions field until frontend does it.
+   * @method
+   * @param {object} record - in frontend format
+   * @returns {object} record - in API format
+   */
+  fillDescriptions(record) {
+    let descriptions = [
+      {
+        description: 'Just a filler description.',
+        lang: 'eng',
+        type: 'Abstract',
+      },
+    ];
+    let metadata = { ...record['metadata'], descriptions };
+
+    return { ...record, metadata };
   }
 }

--- a/src/lib/DepositRecordSerializer.test.js
+++ b/src/lib/DepositRecordSerializer.test.js
@@ -5,72 +5,71 @@
 // React-Invenio-Deposit is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
 
-import { DepositRecordSerializer } from "./DepositRecordSerializer";
-
+import { DepositRecordSerializer } from './DepositRecordSerializer';
 
 describe('Record serializer', () => {
   describe('removeEmptyValues', () => {
     const serializer = new DepositRecordSerializer();
     const record = {
-      contributors: [
-        { identifiers: [] },
-      ],
+      contributors: [{ identifiers: [] }],
       version: 0,
       cool: false,
-      creators: [
-        null,
-        undefined,
-        {},
-      ],
-      description: ""
-    }
+      creators: [null, undefined, {}],
+      description: '',
+    };
 
     const cleanedRecord = serializer.removeEmptyValues(record);
 
-    expect(cleanedRecord).toEqual({version: 0});
+    expect(cleanedRecord).toEqual({ version: 0 });
   });
 
   describe('creators', () => {
     it('transforms identifiers arrays into objects', () => {
       const serializer = new DepositRecordSerializer();
       const record = {
-        creators: [
-          {
-            identifiers: [
-              { scheme: 'Orcid', identifier: '0000-0002-1825-0097' },
-              { scheme: 'foo', identifier: 'bar' },
-            ],
-          },
-          {
-            identifiers: [
-              { scheme: 'ror', identifier: '03yrm5c26' },
-              { scheme: 'baz', identifier: 'zed' },
-            ],
-          },
-        ],
+        metadata: {
+          creators: [
+            {
+              identifiers: [
+                { scheme: 'Orcid', identifier: '0000-0002-1825-0097' },
+                { scheme: 'foo', identifier: 'bar' },
+              ],
+            },
+            {
+              identifiers: [
+                { scheme: 'ror', identifier: '03yrm5c26' },
+                { scheme: 'baz', identifier: 'zed' },
+              ],
+            },
+          ],
+        },
       };
 
       const serialized_record = serializer.serializeCreators(record);
 
-      expect(serialized_record.creators[0].identifiers).toEqual(
-        { Orcid: '0000-0002-1825-0097', foo: 'bar' },
-      );
-      expect(serialized_record.creators[1].identifiers).toEqual(
-        { ror: '03yrm5c26', baz: 'zed' },
-      );
+      expect(serialized_record.creators[0].identifiers).toEqual({
+        Orcid: '0000-0002-1825-0097',
+        foo: 'bar',
+      });
+      expect(serialized_record.creators[1].identifiers).toEqual({
+        ror: '03yrm5c26',
+        baz: 'zed',
+      });
     });
 
     it('picks last scheme if duplicates', () => {
       const serializer = new DepositRecordSerializer();
       const record = {
-        creators: [
-          {
-            identifiers: [
-              { scheme: 'Orcid', identifier: '0000-0002-1825-0097' },
-              { scheme: 'Orcid', identifier: '0000-0002-1825-0098' },
-            ],
-          },
-        ],
+        metadata: {
+          creators: [
+            {
+              identifiers: [
+                { scheme: 'Orcid', identifier: '0000-0002-1825-0097' },
+                { scheme: 'Orcid', identifier: '0000-0002-1825-0098' },
+              ],
+            },
+          ],
+        },
       };
 
       const serialized_record = serializer.serializeCreators(record);
@@ -85,20 +84,22 @@ describe('Record serializer', () => {
     it('transforms identifiers arrays into objects', () => {
       const serializer = new DepositRecordSerializer();
       const record = {
-        contributors: [
-          {
-            identifiers: [
-              { scheme: 'Orcid', identifier: '0000-0002-1825-0097' },
-              { scheme: 'foo', identifier: 'bar' },
-            ],
-          },
-          {
-            identifiers: [
-              { scheme: 'ror', identifier: '03yrm5c26' },
-              { scheme: 'baz', identifier: 'zed' },
-            ],
-          },
-        ],
+        metadata: {
+          contributors: [
+            {
+              identifiers: [
+                { scheme: 'Orcid', identifier: '0000-0002-1825-0097' },
+                { scheme: 'foo', identifier: 'bar' },
+              ],
+            },
+            {
+              identifiers: [
+                { scheme: 'ror', identifier: '03yrm5c26' },
+                { scheme: 'baz', identifier: 'zed' },
+              ],
+            },
+          ],
+        },
       };
 
       const serialized_record = serializer.serializeContributors(record);
@@ -116,14 +117,16 @@ describe('Record serializer', () => {
     it('picks last scheme if duplicates', () => {
       const serializer = new DepositRecordSerializer();
       const record = {
-        contributors: [
-          {
-            identifiers: [
-              { scheme: 'Orcid', identifier: '0000-0002-1825-0097' },
-              { scheme: 'Orcid', identifier: '0000-0002-1825-0098' },
-            ],
-          },
-        ],
+        metadata: {
+          contributors: [
+            {
+              identifiers: [
+                { scheme: 'Orcid', identifier: '0000-0002-1825-0097' },
+                { scheme: 'Orcid', identifier: '0000-0002-1825-0098' },
+              ],
+            },
+          ],
+        },
       };
 
       const serialized_record = serializer.serializeContributors(record);
@@ -147,25 +150,25 @@ describe('Record serializer', () => {
 
       // if contributors only have type defined, empty it out
       record = {
-        contributors: [
-          {
-            type: "Personal"
-          },
-          {
-            type: "Organizational"
-          }
-        ]
+        metadata: {
+          contributors: [
+            {
+              type: 'Personal',
+            },
+            {
+              type: 'Organizational',
+            },
+          ],
+        },
       };
 
       serialized_record = serializer.serializeContributors(record);
 
-      expect(serialized_record).toEqual({});
+      expect(serialized_record).toEqual({ metadata: {} });
 
       // if identifiers is absent, leave absent
       record = {
-        contributors: [
-          { name: "Alice" }
-        ],
+        contributors: [{ name: 'Alice' }],
       };
 
       serialized_record = serializer.serializeContributors(record);
@@ -177,11 +180,11 @@ describe('Record serializer', () => {
   describe('deserialize', () => {
     const serializer = new DepositRecordSerializer();
     const record = {
-      foo: "bar"
-    }
+      foo: 'bar',
+    };
 
     const deserializedRecord = serializer.deserialize(record);
 
     expect(deserializedRecord).toEqual(record);
   });
-})
+});

--- a/src/lib/components/AccessRightField.js
+++ b/src/lib/components/AccessRightField.js
@@ -7,7 +7,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-import { FieldLabel, RadioField, GroupField } from 'react-invenio-forms';
+import { ErrorLabel, FieldLabel, RadioField, GroupField } from 'react-invenio-forms';
 import { Card, Form } from 'semantic-ui-react';
 
 export class AccessRightField extends Component {
@@ -32,18 +32,19 @@ export class AccessRightField extends Component {
           <GroupField fieldPath={fieldPath} grouped>
             <Form.Field required>
               <FieldLabel htmlFor={fieldPath} icon={labelIcon} label={label} />
+              {options.map((option) => (
+                <RadioField
+                  fieldPath={fieldPath}
+                  label={option.text}
+                  labelIcon={option.icon}
+                  key={option.value}
+                  value={option.value}
+                  checked={this.state.selected === option.value}
+                  onChange={this.handleChange}
+                />
+              ))}
+              <ErrorLabel fieldPath={fieldPath} />
             </Form.Field>
-            {options.map((option) => (
-              <RadioField
-                fieldPath={fieldPath}
-                label={option.text}
-                labelIcon={option.icon}
-                key={option.value}
-                value={option.value}
-                checked={this.state.selected === option.value}
-                onChange={this.handleChange}
-              />
-            ))}
           </GroupField>
         </Card.Content>
       </Card>

--- a/src/lib/components/CreatorOrContributorField.js
+++ b/src/lib/components/CreatorOrContributorField.js
@@ -86,28 +86,21 @@ const _CreatorOrContributorField = ({ field, form, ...props }) => {
         placeholder="Select type of creator"
       />
 
-      {isPerson ? (
-        <>
-          <TextField
-            fieldPath={familyNameFieldPath}
-            onChange={handleGivenOrFamilyNameChange}
-            label={'Family Name'}
-          />
-          <TextField
-            fieldPath={givenNameFieldPath}
-            onChange={handleGivenOrFamilyNameChange}
-            label={'Given Name'}
-          />
-          {isContributor && (
-            <SelectField
-              fieldPath={roleFieldPath}
-              label={'Role'}
-              options={options.role}
-              placeholder="Select contributor role"
-            />
-          )}
+      <TextField
+        fieldPath={nameFieldPath}
+        label={'Name'}
+        required={!isContributor}
+      />
 
-          {/*
+      {isContributor && (
+        <SelectField
+          fieldPath={roleFieldPath}
+          label={'Role'}
+          options={options.role}
+          placeholder="Select contributor role"
+        />
+      )}
+      {/*
             TODO: Implement Affiliations field
           <ArrayField
             addButtonLabel={'Add affiliation'}
@@ -143,21 +136,6 @@ const _CreatorOrContributorField = ({ field, form, ...props }) => {
               </GroupField>
             )}
           </ArrayField> */}
-        </>
-      ) : (
-        <>
-          <TextField fieldPath={nameFieldPath} label={'Name'} />
-
-          {isContributor && (
-            <SelectField
-              fieldPath={roleFieldPath}
-              label={'Role'}
-              options={options.role}
-              placeholder="Select contributor role"
-            />
-          )}
-        </>
-      )}
 
       <ArrayField
         addButtonLabel={'Add identifier'}

--- a/src/lib/components/CreatorsField.js
+++ b/src/lib/components/CreatorsField.js
@@ -59,6 +59,7 @@ export class CreatorsField extends Component {
         fieldPath={fieldPath}
         label={label}
         labelIcon={labelIcon}
+        required
       >
         {({ array, arrayHelpers, indexPath, key }) => (
           <>

--- a/src/lib/components/IdentifierField.js
+++ b/src/lib/components/IdentifierField.js
@@ -22,7 +22,6 @@ export class IdentifierField extends Component {
           fieldPath={schemeFieldPath}
           label={'Scheme'}
           options={schemeOptions}
-          clearable
         />
         <TextField fieldPath={identifierFieldPath} label="Identifier" />
       </>

--- a/src/lib/components/ResourceTypeField.js
+++ b/src/lib/components/ResourceTypeField.js
@@ -8,17 +8,19 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { getIn, Field } from 'formik';
+import _get from 'lodash/get';
 
 import { FieldLabel, GroupField, SelectField } from 'react-invenio-forms';
 
 export class ResourceTypeField extends Component {
-  hasGroupErrors = (errors) => {
+
+  groupErrors = (errors) => {
     for (const field in errors) {
       if (field.startsWith(this.props.fieldPath)) {
-        return true;
+        return { content: _get(errors, this.props.fieldPath) };
       }
     }
-    return false;
+    return null;
   };
 
   renderResourceTypeField = (formikBag) => {
@@ -39,11 +41,7 @@ export class ResourceTypeField extends Component {
     return (
       <GroupField widths="equal">
         <SelectField
-          error={
-            this.hasGroupErrors(formikBag.form.errors)
-              ? { content: getIn(formikBag.form.errors, this.props.fieldPath) }
-              : null
-          }
+          error={this.groupErrors(formikBag.form.errors)}
           fieldPath={typeFieldPath}
           label={
             <FieldLabel

--- a/src/lib/components/TitlesField.js
+++ b/src/lib/components/TitlesField.js
@@ -62,7 +62,6 @@ export class TitlesField extends Component {
               fieldPath={`${key}.${typeSegment}`}
               label={'Type'}
               options={options.type}
-              clearable
             />
             <SelectField
               fieldPath={`${key}.${languageSegment}`}
@@ -70,7 +69,7 @@ export class TitlesField extends Component {
               options={options.lang}
               clearable
             />
-            {array.length !== 1 && (
+            {array.length > 1 && (
               <Form.Field>
                 <Form.Field>
                   <label>&nbsp;</label>

--- a/src/lib/state/actions/deposit.js
+++ b/src/lib/state/actions/deposit.js
@@ -7,10 +7,16 @@
 
 import { FORM_ACTION_FAILED, FORM_ACTION_EVENT_EMITTED } from '../types';
 
-export const setFormErrorsFromResponse = (response, formik) => {
+
+/**
+ * Closure over Axios error and formik, returning async error setting function.
+ *
+ * @param {Error} error - Axios error
+ * @param {Formik state} formik
+ */
+export const setFormErrors = (error, formik, record) => {
   return async (dispatch, getState, config) => {
-    const errorHandler = config.apiErrorHandler;
-    const extractedErrors = errorHandler.extractErrors(response);
+    const extractedErrors = config.apiErrorHandler.extractErrors(error, record);
     dispatch({
       type: FORM_ACTION_FAILED,
     });


### PR DESCRIPTION
**EDIT**: See comment about it not being rebased. I leave it up to you to decide.

work in progress of frontend errors. Here is a screenshot of how things look like currently:

![oct5_upload_errors](https://user-images.githubusercontent.com/1932651/95137297-5d968380-072d-11eb-89db-a026939f6df0.png)

Co need:
- https://github.com/inveniosoftware/invenio-app-rdm/pull/293
- https://github.com/inveniosoftware/invenio-rdm-records/pull/182
 
To note:
- I replaced "family name" / "given name" by "Name" because the backend does validation against name and it's simpler for now to get both person and organization dealt with in 1 swoop.

Things that need to be done:
- Not send a contributor that is empty except for `type` by default: this makes the backend validate it and return an error on the frontend.
- Convert machine values to human labels for access radio button. I think this conversion should take place on the frontend. Translation here will be a challenge.
- Deal with resource type error correctly
 