### PR TITLE
files: don't clear form when clicking metadata-only

### DIFF
--- a/src/lib/DepositApiClient.js
+++ b/src/lib/DepositApiClient.js
@@ -118,6 +118,8 @@ export class DepositApiClient {
     );
   }
 
+  // TODO: Might consider extracting these out to a FilesApiClient.js
+
   initializeFileUpload(initializeUploadUrl, filename) {
     const payload = [
       {
@@ -160,11 +162,21 @@ export class DepositApiClient {
     return axios.delete(deleteUrl);
   }
 
-  setFileMetadata(setFileMetadataUrl, data) {
-    return axios.put(setFileMetadataUrl, data, {
-      headers: {
-        'content-type': 'application/json',
-      },
-    });
+  /**
+   * Sets the files metadata (enabled, default preview).
+   *
+   * @param {string} setFileMetadataUrl - the Files API URL
+   * @param {object} data - the files metadata
+   */
+  async setFilesMetadata(setFileMetadataUrl, data) {
+    return this.createResponse(() =>
+      axios.put(
+        setFileMetadataUrl,
+        data,
+        {
+          headers: { 'Content-Type': 'application/json' },
+        }
+      )
+    );
   }
 }

--- a/src/lib/DepositBootstrap/DepositBootstrap.js
+++ b/src/lib/DepositBootstrap/DepositBootstrap.js
@@ -1,6 +1,6 @@
 // This file is part of React-Invenio-Deposit
-// Copyright (C) 2020 CERN.
-// Copyright (C) 2020 Northwestern University.
+// Copyright (C) 2020-2021 CERN.
+// Copyright (C) 2020-2021 Northwestern University.
 //
 // React-Invenio-Deposit is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
@@ -9,7 +9,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { BaseForm } from 'react-invenio-forms';
 import { Container } from 'semantic-ui-react';
-import { UploadState } from '../state/reducers/files';
 
 export default class DepositBootstrap extends Component {
   componentDidMount() {
@@ -26,15 +25,11 @@ export default class DepositBootstrap extends Component {
     });
   }
 
-  onSubmit = (values, formikBag) => {
-    this.props.submitFormData(values, formikBag);
-  };
-
   render() {
     return (
       <Container style={{ marginTop: '35px' }}>
         <BaseForm
-          onSubmit={this.onSubmit}
+          onSubmit={this.props.submitFormData}
           formik={{
             enableReinitialize: true,
             initialValues: this.props.record,

--- a/src/lib/DepositFileUploader.js
+++ b/src/lib/DepositFileUploader.js
@@ -1,6 +1,6 @@
 // This file is part of React-Invenio-Deposit
-// Copyright (C) 2020 CERN.
-// Copyright (C) 2020 Northwestern University.
+// Copyright (C) 2020-2021 CERN.
+// Copyright (C) 2020-2021 Northwestern University.
 //
 // React-Invenio-Deposit is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
@@ -203,29 +203,32 @@ export class DepositFileUploader {
   };
 
   setDefaultPreview = async (defaultPreviewUrl, defaultPreview, { store }) => {
-    try {
-      const resp = await this.apiClient.setFileMetadata(defaultPreviewUrl, {
-        default_preview: defaultPreview,
-      });
+    const response = await this.apiClient.setFilesMetadata(defaultPreviewUrl, {
+      default_preview: defaultPreview,
+    });
+    if ( 200 <= response.code && response.code < 300 ) {
       store.dispatch({
         type: SET_DEFAULT_PREVIEW_FILE,
         payload: { filename: defaultPreview },
       });
-    } catch (e) {
+    } else {
       store.dispatch({ type: SET_DEFAULT_PREVIEW_FILE_FAILED });
     }
   };
 
   setFilesEnabled = async (enableFileUrl, filesEnabled, { store }) => {
-    try {
-      const resp = await this.apiClient.setFileMetadata(enableFileUrl, {
-        enabled: filesEnabled,
-      });
+    const response = await this.apiClient.setFilesMetadata(enableFileUrl, {
+      enabled: filesEnabled,
+    });
+    if ( 200 <= response.code && response.code < 300 ) {
       store.dispatch({
         type: SET_FILES_ENABLED,
-        payload: { filesEnabled: resp.data.enabled, links: resp.data.links },
+        payload: {
+          filesEnabled: response.data.enabled,
+          links: response.data.links
+        },
       });
-    } catch (e) {
+    } else {
       store.dispatch({ type: SET_FILES_ENABLED_FAILED });
     }
   };

--- a/src/lib/components/FileUploader/FileUploader.js
+++ b/src/lib/components/FileUploader/FileUploader.js
@@ -96,16 +96,18 @@ export default class FileUploader extends Component {
             />
           )}
         </Grid.Row>
-        <Grid.Row className="file-upload-area-row">
-          <FileUploaderArea
-            {...this.props}
-            filesEnabled={filesEnabled}
-            filesList={filesList}
-            dropzoneParams={dropzoneParams}
-            isDraftRecord={isDraftRecord}
-            defaultFilePreview={this.props.defaultFilePreview}
-          />
-        </Grid.Row>
+        {filesEnabled && (<>
+          <Grid.Row className="file-upload-area-row">
+            <FileUploaderArea
+              {...this.props}
+              filesEnabled={filesEnabled}
+              filesList={filesList}
+              dropzoneParams={dropzoneParams}
+              isDraftRecord={isDraftRecord}
+              defaultFilePreview={this.props.defaultFilePreview}
+            />
+          </Grid.Row>
+        </>)}
         <Grid.Row className="file-upload-note-row">
           <Grid.Column width={16}>
             <Segment basic className="file-upload-note">

--- a/src/lib/components/FileUploader/FileUploader.js
+++ b/src/lib/components/FileUploader/FileUploader.js
@@ -1,6 +1,6 @@
 // This file is part of React-Invenio-Deposit
-// Copyright (C) 2020 CERN.
-// Copyright (C) 2020 Northwestern University.
+// Copyright (C) 2020-2021 CERN.
+// Copyright (C) 2020-2021 Northwestern University.
 //
 // React-Invenio-Deposit is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
@@ -13,11 +13,6 @@ import { FileUploaderToolbar } from './FileUploaderToolbar';
 import { UploadState } from '../../state/reducers/files';
 
 export default class FileUploader extends Component {
-  onMetadataOnlyClick = (event, data) => {
-    if (!data['disabled']) {
-      this.props.setFilesEnabled(!this.props.filesEnabled);
-    }
-  };
 
   render() {
     const {
@@ -28,6 +23,7 @@ export default class FileUploader extends Component {
       config,
       filesEnabled,
       isDraftRecord,
+      setFilesEnabled,
     } = this.props;
     let filesList = Object.values(files).map((fileState) => {
       return {
@@ -87,12 +83,12 @@ export default class FileUploader extends Component {
           {isDraftRecord && (
             <FileUploaderToolbar
               {...this.props}
-              onMetadataOnlyClick={this.onMetadataOnlyClick}
               filesSize={filesSize}
               filesList={filesList}
               isDraftRecord={isDraftRecord}
               config={config}
               filesEnabled={filesEnabled}
+              setFilesEnabled={setFilesEnabled}
             />
           )}
         </Grid.Row>

--- a/src/lib/components/FileUploader/FileUploaderToolbar.js
+++ b/src/lib/components/FileUploader/FileUploaderToolbar.js
@@ -42,31 +42,33 @@ export const FileUploaderToolbar = ({
           </List>
         )}
       </Grid.Column>
-      <Grid.Column width={8} floated="right">
-        <List horizontal floated="right">
-          <List.Item>Storage available</List.Item>
-          <List.Item>
-            <Label
-              {...(filesList.length === quota.maxFiles
-                ? { color: 'blue' }
-                : {})}
-            >
-              {filesList.length} out of {quota.maxFiles} files
-            </Label>
-          </List.Item>
-          <List.Item>
-            <Label
-              {...(humanReadableBytes(filesSize) ===
-              humanReadableBytes(quota.maxStorage)
-                ? { color: 'blue' }
-                : {})}
-            >
-              {humanReadableBytes(filesSize)} out of{' '}
-              {humanReadableBytes(quota.maxStorage)}
-            </Label>
-          </List.Item>
-        </List>
-      </Grid.Column>
+      {filesEnabled &&
+        <Grid.Column width={8} floated="right">
+          <List horizontal floated="right">
+            <List.Item>Storage available</List.Item>
+            <List.Item>
+              <Label
+                {...(filesList.length === quota.maxFiles
+                  ? { color: 'blue' }
+                  : {})}
+              >
+                {filesList.length} out of {quota.maxFiles} files
+              </Label>
+            </List.Item>
+            <List.Item>
+              <Label
+                {...(humanReadableBytes(filesSize) ===
+                humanReadableBytes(quota.maxStorage)
+                  ? { color: 'blue' }
+                  : {})}
+              >
+                {humanReadableBytes(filesSize)} out of{' '}
+                {humanReadableBytes(quota.maxStorage)}
+              </Label>
+            </List.Item>
+          </List>
+        </Grid.Column>
+      }
     </>
   );
 };

--- a/src/lib/components/FileUploader/FileUploaderToolbar.js
+++ b/src/lib/components/FileUploader/FileUploaderToolbar.js
@@ -1,22 +1,27 @@
 // This file is part of React-Invenio-Deposit
-// Copyright (C) 2020 CERN.
-// Copyright (C) 2020 Northwestern University.
+// Copyright (C) 2020-2021 CERN.
+// Copyright (C) 2020-2021 Northwestern University.
 //
 // React-Invenio-Deposit is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
 import React from 'react';
+import { useFormikContext } from 'formik';
 import { Checkbox, Grid, Icon, Label, List, Popup } from 'semantic-ui-react';
 import { humanReadableBytes } from './utils';
 
+// NOTE: This component has to be a function component to allow
+//       the `useFormikContext` hook.
 export const FileUploaderToolbar = ({
-  onMetadataOnlyClick,
-  quota,
+  config,
   filesList,
   filesSize,
   filesEnabled,
-  config,
-  ...props
+  quota,
+  setFilesEnabled,
 }) => {
+  // We extract the working copy of the draft stored as `values` in formik
+  const { values } = useFormikContext();
+
   return (
     <>
       <Grid.Column width={8} verticalAlign="middle" floated="left">
@@ -24,8 +29,14 @@ export const FileUploaderToolbar = ({
           <List horizontal>
             <List.Item>
               <Checkbox
-                label={'Metadata only record'}
-                onClick={onMetadataOnlyClick}
+                label={'Metadata-only record'}
+                onClick={
+                  (event, data) => {
+                    if (!data['disabled']) {  // if checkbox is not disabled
+                      setFilesEnabled(values, !filesEnabled);
+                    }
+                  }
+                }
                 disabled={filesList.length > 0}
                 checked={!filesEnabled}
               />
@@ -50,7 +61,8 @@ export const FileUploaderToolbar = ({
               <Label
                 {...(filesList.length === quota.maxFiles
                   ? { color: 'blue' }
-                  : {})}
+                  : {})
+                }
               >
                 {filesList.length} out of {quota.maxFiles} files
               </Label>
@@ -58,9 +70,10 @@ export const FileUploaderToolbar = ({
             <List.Item>
               <Label
                 {...(humanReadableBytes(filesSize) ===
-                humanReadableBytes(quota.maxStorage)
+                  humanReadableBytes(quota.maxStorage)
                   ? { color: 'blue' }
-                  : {})}
+                  : {})
+                }
               >
                 {humanReadableBytes(filesSize)} out of{' '}
                 {humanReadableBytes(quota.maxStorage)}

--- a/src/lib/components/FileUploader/index.js
+++ b/src/lib/components/FileUploader/index.js
@@ -1,3 +1,10 @@
+// This file is part of React-Invenio-Deposit
+// Copyright (C) 2020-2021 CERN.
+// Copyright (C) 2020-2021 Northwestern University.
+//
+// React-Invenio-Deposit is free software; you can redistribute it and/or modify it
+// under the terms of the MIT License; see LICENSE file for more details.
+
 import React from 'react';
 import { connect } from 'react-redux';
 import FileUploaderComponent from './FileUploader';
@@ -21,11 +28,10 @@ const mapStateToProps = (state) => {
 };
 
 const mapDispatchToProps = (dispatch) => ({
-  uploadFilesToDraft: (record, files) =>
-    dispatch(uploadDraftFiles(record, files)),
+  uploadFilesToDraft: (draft, files) => dispatch(uploadDraftFiles(draft, files)),
   deleteFileFromRecord: (file) => dispatch(deleteDraftFile(file)),
   setDefaultPreviewFile: (filename) => dispatch(setDefaultPreview(filename)),
-  setFilesEnabled: (filesEnabled) => dispatch(setFilesEnabled(filesEnabled)),
+  setFilesEnabled: (draft, filesEnabled) => dispatch(setFilesEnabled(draft, filesEnabled)),
 });
 
 export const FileUploader = connect(

--- a/src/lib/state/actions/files.js
+++ b/src/lib/state/actions/files.js
@@ -1,14 +1,14 @@
 // This file is part of React-Invenio-Deposit
-// Copyright (C) 2020 CERN.
-// Copyright (C) 2020 Northwestern University.
+// Copyright (C) 2020-2021 CERN.
+// Copyright (C) 2020-2021 Northwestern University.
 //
 // React-Invenio-Deposit is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
 
-export const uploadDraftFiles = (record, files) => {
+export const uploadDraftFiles = (draft, files) => {
   return async (dispatch, getState, config) => {
     const controller = config.controller;
-    controller.uploadDraftFiles(record, files, {
+    controller.uploadDraftFiles(draft, files, {
       store: { dispatch, getState, config },
     });
   };
@@ -33,11 +33,10 @@ export const setDefaultPreview = (filename) => {
   };
 };
 
-export const setFilesEnabled = (filesEnabled) => {
+export const setFilesEnabled = (draft, filesEnabled) => {
   return async (dispatch, getState, config) => {
     const controller = config.controller;
-    const draftRecord = getState().deposit.record;
-    controller.setFilesEnabled(draftRecord, filesEnabled, {
+    controller.setFilesEnabled(draft, filesEnabled, {
       store: { dispatch, getState, config },
     });
   };


### PR DESCRIPTION
- closes https://github.com/inveniosoftware/react-invenio-deposit/issues/147
- hides rest of file upload when metadata-only is clicked

![image](https://user-images.githubusercontent.com/1932651/105223105-f3a9ba80-5b20-11eb-9226-c05bcdbd6277.png)
(font size change in invenio-app-rdm)

- refactors some code a little / more to come