### PR TITLE
resource_type field: merge dual dropdown into one [+]

### DIFF
--- a/src/lib/components/ResourceTypeField.js
+++ b/src/lib/components/ResourceTypeField.js
@@ -1,81 +1,114 @@
 // This file is part of React-Invenio-Deposit
-// Copyright (C) 2020 CERN.
-// Copyright (C) 2020 Northwestern University.
+// Copyright (C) 2020-2021 CERN.
+// Copyright (C) 2020-2021 Northwestern University.
 //
 // React-Invenio-Deposit is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Field } from 'formik';
+import { FastField } from 'formik';
 import _get from 'lodash/get';
+import { Form } from 'semantic-ui-react';
 
-import { FieldLabel, GroupField, SelectField } from 'react-invenio-forms';
+import { FieldLabel } from 'react-invenio-forms';
 
 export class ResourceTypeField extends Component {
-  groupErrors = (errors) => {
-    for (const field in errors) {
-      if (field.startsWith(this.props.fieldPath)) {
-        return { content: _get(errors, this.props.fieldPath) };
-      }
+  groupErrors = (errors, fieldPath) => {
+    const fieldErrors = _get(errors, fieldPath);
+    if (fieldErrors) {
+      return { content: fieldErrors };
     }
     return null;
   };
 
-  renderResourceTypeField = (formikBag) => {
-    const typeFieldPath = `${this.props.fieldPath}.type`;
-    const subtypeFieldPath = `${this.props.fieldPath}.subtype`;
+  createOptions = (propsOptions) => {
+    let options = [];
+    for (const type of propsOptions.type) {
+      const subtypes = propsOptions.subtype.filter(
+        (e) => e['parent-value'] === type.value
+      );
 
-    const resource_type = _get(formikBag.form.values, typeFieldPath, '');
+      if (subtypes.length > 0) {
+        // Push options corresponding to each subtype
+        options.push(
+          ...subtypes.map((subtype) => ({
+            // NOTE: In this version of semantic-ui-react (0.88.2),
+            // using icon key doesn't show icon in selected text. This does:
+            text: <><i className={type.icon + " icon"}></i><span className="text">{subtype["parent-text"] + " / " + subtype.text}</span></>,
+            value: subtype["parent-value"] + "/" + subtype.value,
+            values: {type: type.value, subtype: subtype.value}
+          }))
+        );
+      } else {
+        // Push an option corresponding to the type only
+        options.push({
+            icon: type.icon,
+            text: type.text,
+            value: type.value,
+            values: {type: type.value}
+        })
+      }
+    }
+    return options;
+  }
 
-    const handleChange = ({ event, data: selectedOption }) => {
-      formikBag.form.setFieldValue(typeFieldPath, selectedOption.value);
-      formikBag.form.setFieldValue(subtypeFieldPath, '');
-    };
+  loadValue(values, fieldPath) {
+    const resourceType = _get(values, fieldPath);
+    let value;
+    if (resourceType && resourceType.type) {
+      value = resourceType.type + (resourceType.subtype ? "/" + resourceType.subtype : "");
+    } else {
+      value = "";
+    }
+    return value;
+  }
 
-    const subtypeOptions = this.props.options.subtype.filter(
-      (e) => e['parent-value'] === resource_type
-    );
+  renderResourceTypeField = ({ field, form }) => {
+    // 1- create the master list of options
+    const options = this.createOptions(this.props.options);
+
+    // 2- handlechange grabs the values of the selected option and sticks those
+    //    in form.values
+    const handleChange = ( event, data ) => {
+      const option = data.options.find((e) => e.value === data.value);
+      form.setFieldValue(this.props.fieldPath, option.values);
+    }
+
+    // 3- loads/displays the correct value from the dropdown
+    //    If no initial value, value must be set to "" for placeholder to display.
+    let value = this.loadValue(form.values, this.props.fieldPath);
 
     return (
-      <GroupField widths="equal">
-        <SelectField
-          error={this.groupErrors(formikBag.form.errors)}
-          fieldPath={typeFieldPath}
-          label={
-            <FieldLabel
-              htmlFor={typeFieldPath}
-              icon={this.props.labelIcon}
-              label={this.props.label}
-            />
-          }
-          options={this.props.options.type}
-          onChange={handleChange}
-          placeholder="Select general resource type"
-          required={this.props.required}
-        />
-        {subtypeOptions.length > 0 && (
-          <SelectField
-            fieldPath={subtypeFieldPath}
-            label={
-              <FieldLabel
-                htmlFor={subtypeFieldPath}
-                icon={this.props.labelIcon}
-                label={this.props.subtypeLabel}
-              />
-            }
-            options={subtypeOptions}
-            placeholder="Select resource subtype"
-            required
+      // NOTE: we are using a semantic-ui Form.Dropdown directly because
+      //       - we need more control
+      //       - this field is just for show - the formik logic is done behind
+      //         the scenes
+      <Form.Dropdown
+        fluid
+        selection
+        error={this.groupErrors(form.errors, this.props.fieldPath)}
+        id={this.props.fieldPath}
+        label={
+          <FieldLabel
+            htmlFor={this.props.fieldPath}
+            icon={this.props.labelIcon}
+            label={this.props.label}
           />
-        )}
-      </GroupField>
+        }
+        name={this.props.fieldPath}
+        onChange={handleChange}
+        options={options}
+        placeholder={"Select resource type"}
+        required={this.props.required}
+        value={value}
+      />
     );
   };
 
   render() {
     return (
-      <Field
+      <FastField
         name={this.props.fieldPath}
         component={this.renderResourceTypeField}
       />
@@ -104,7 +137,6 @@ ResourceTypeField.propTypes = {
       })
     ),
   }).isRequired,
-  subtypeLabel: PropTypes.string,
   required: PropTypes.bool,
 };
 
@@ -112,5 +144,4 @@ ResourceTypeField.defaultProps = {
   fieldPath: 'metadata.resource_type',
   label: 'Resource type',
   labelIcon: 'tag',
-  subtypeLabel: 'Resource Subtype',
 };


### PR DESCRIPTION
- closes #78 

Also include a lot of improvements:

- Use FastField (quite satisfying to see this field's re-rendering
  NOT triggered by every keystroke in another field).
- Display icon of selected option in the selected field
- Display error correctly

**Screenshots**

Icons:
![resourcetype_dropdown](https://user-images.githubusercontent.com/1932651/105389138-1b5e5880-5bdd-11eb-9cd2-40ff916955c9.png)

Error:
![resourcetype_error](https://user-images.githubusercontent.com/1932651/105389148-1dc0b280-5bdd-11eb-98cd-9e63caad60eb.png)
