### PR TITLE
license: split dropdown to two buttons

### DIFF
--- a/src/lib/components/License/LicenseField.js
+++ b/src/lib/components/License/LicenseField.js
@@ -9,7 +9,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { getIn, FieldArray } from 'formik';
 
-import { Button, Form, Dropdown, List, Icon } from 'semantic-ui-react';
+import { Button, Form, List, Icon } from 'semantic-ui-react';
 
 import { FieldLabel } from 'react-invenio-forms';
 import { LicenseModal } from './LicenseModal';
@@ -70,28 +70,34 @@ export class LicenseField extends Component {
               </List.Item>
             );
           })}
-          <Dropdown className="add-licenses" text="Add a license" simple>
-            <Dropdown.Menu>
-              <LicenseModal
-                searchConfig={this.props.searchConfig}
-                trigger={<Dropdown.Item key="standard" text="Add standard" />}
-                onLicenseChange={(selectedLicense) => {
-                  arrayHelpers.push(selectedLicense);
-                }}
-                mode="standard"
-                action="add"
-              />
-              <LicenseModal
-                searchConfig={this.props.searchConfig}
-                trigger={<Dropdown.Item key="custom" text="Create custom" />}
-                onLicenseChange={(selectedLicense) => {
-                  arrayHelpers.push(selectedLicense);
-                }}
-                mode="custom"
-                action="add"
-              />
-            </Dropdown.Menu>
-          </Dropdown>
+          <LicenseModal
+            searchConfig={this.props.searchConfig}
+            trigger={
+              <Button type="button" key="standard" className="add-licenses">
+                <Icon name="add" />
+                Add standard
+              </Button>
+            }
+            onLicenseChange={(selectedLicense) => {
+              arrayHelpers.push(selectedLicense);
+            }}
+            mode="standard"
+            action="add"
+          />
+          <LicenseModal
+            searchConfig={this.props.searchConfig}
+            trigger={
+              <Button type="button" key="custom" className="add-licenses">
+                <Icon name="pencil" />
+                Create custom
+              </Button>
+            }
+            onLicenseChange={(selectedLicense) => {
+              arrayHelpers.push(selectedLicense);
+            }}
+            mode="custom"
+            action="add"
+          />
         </List>
       </Form.Field>
     );

--- a/src/lib/components/License/LicenseModal.js
+++ b/src/lib/components/License/LicenseModal.js
@@ -83,13 +83,7 @@ export class LicenseModal extends Component {
           onOpen={() => this.openModal()}
           open={this.state.open}
           trigger={this.props.trigger}
-          onClick={(e) => {
-            // NOTE: temporary fix for https://github.com/Semantic-Org/Semantic-UI-React/issues/3174
-            e.stopPropagation();
-          }}
-          // TODO: temporary fix as the modal results require to scroll down
-          // to find the cancel button
-          closeOnDimmerClick={true}
+          onClose={this.closeModal}
         >
           <Modal.Header as="h6" className="license-modal-header">
             <Grid>

--- a/src/lib/components/License/LicenseModal.js
+++ b/src/lib/components/License/LicenseModal.js
@@ -106,7 +106,7 @@ export class LicenseModal extends Component {
               </Grid.Column>
             </Grid>
           </Modal.Header>
-          <Modal.Content>
+          <Modal.Content scrolling>
             {this.props.mode === ModalTypes.STANDARD && (
               <OverridableContext.Provider value={overriddenComponents}>
                 <ReactSearchKit


### PR DESCRIPTION
closes https://github.com/inveniosoftware/invenio-app-rdm/issues/463
closes https://github.com/inveniosoftware/react-invenio-deposit/issues/152

<img width="914" alt="Screenshot 2021-01-22 at 14 57 10" src="https://user-images.githubusercontent.com/22594783/105499684-2343f880-5cc2-11eb-835b-149ed610f65f.png">

* Makes also modal content scrollable
<img width="1175" alt="Screenshot 2021-01-22 at 10 49 33" src="https://user-images.githubusercontent.com/22594783/105475328-896b5400-5c9f-11eb-85e3-677be610ecbf.png">
