### PR TITLE
resoucetypefield: create label without FieldLabel

### DIFF
--- a/src/lib/components/RelatedWorksField.js
+++ b/src/lib/components/RelatedWorksField.js
@@ -1,6 +1,7 @@
 // This file is part of React-Invenio-Deposit
 // Copyright (C) 2020-2021 CERN.
 // Copyright (C) 2020-2021 Northwestern University.
+// Copyright (C) 2021 Graz University of Technology.
 //
 // React-Invenio-Deposit is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
@@ -64,6 +65,7 @@ export class RelatedWorksField extends Component {
               labelIcon={''}  // Otherwise breaks alignment
               options={options.resource_type}
               width={6}
+              labelClassName="small field-label-class"
             />
 
             <Form.Field width={1}>

--- a/src/lib/components/ResourceTypeField.js
+++ b/src/lib/components/ResourceTypeField.js
@@ -72,6 +72,7 @@ export class ResourceTypeField extends Component {
       labelIcon,
       options,
       required,
+      labelClassName,
       ...uiProps
     } = this.props;
 
@@ -107,6 +108,7 @@ export class ResourceTypeField extends Component {
             htmlFor={fieldPath}
             icon={labelIcon}
             label={label}
+            className={labelClassName}
           />
         }
         name={fieldPath}
@@ -134,6 +136,7 @@ ResourceTypeField.propTypes = {
   fieldPath: PropTypes.string,
   label: PropTypes.string,
   labelIcon: PropTypes.string,
+  labelClassName: PropTypes.string,
   options: PropTypes.shape({
     type: PropTypes.arrayOf(
       PropTypes.shape({
@@ -158,4 +161,5 @@ ResourceTypeField.defaultProps = {
   fieldPath: 'metadata.resource_type',
   label: 'Resource type',
   labelIcon: 'tag',
+  labelClassName: 'field-label-class',
 };


### PR DESCRIPTION
(note) This component is used in both (top-level) and (sub-level) fields.
closes #88