### PR TITLE
licenses: truncate description

### DIFF
--- a/src/lib/components/License/LicenseField.js
+++ b/src/lib/components/License/LicenseField.js
@@ -44,6 +44,7 @@ class LicenseFieldForm extends Component {
               const key = `${arrayPath}.${indexPath}`;
               const licenseType = value.id ? 'standard' : 'custom';
               const description = getIn(values, `${key}.description`, '');
+              const link = getIn(values, `${key}.link`, '');
               const title = getIn(values, `${key}.title`, '');
               return (
                 <LicenseFieldItem
@@ -60,6 +61,7 @@ class LicenseFieldForm extends Component {
                     removeLicense: formikArrayRemove,
                     searchConfig: this.props.searchConfig,
                     serializeLicenses: this.props.serializeLicenses,
+                    link: link,
                   }}
                 />
               );

--- a/src/lib/components/License/LicenseFieldItem.js
+++ b/src/lib/components/License/LicenseFieldItem.js
@@ -1,6 +1,7 @@
 // This file is part of React-Invenio-Deposit
 // Copyright (C) 2021 CERN.
 // Copyright (C) 2021 Northwestern University.
+// Copyright (C) 2021 Graz University of Technology.
 //
 // React-Invenio-Deposit is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
@@ -8,7 +9,7 @@
 import React, { Component } from 'react';
 import { useDrag, useDrop } from 'react-dnd';
 import { Button, List, Ref } from 'semantic-ui-react';
-
+import _truncate from 'lodash/truncate';
 import { LicenseModal } from './LicenseModal';
 
 export const LicenseFieldItem = ({
@@ -23,6 +24,7 @@ export const LicenseFieldItem = ({
   removeLicense,
   searchConfig,
   serializeLicenses,
+  link,
 }) => {
   const dropRef = React.useRef(null);
   const [_, drag, preview] = useDrag({
@@ -93,7 +95,16 @@ export const LicenseFieldItem = ({
           <List.Content>
             <List.Header>{licenseTitle}</List.Header>
             {licenseDescription && (
-              <List.Description>{licenseDescription}</List.Description>
+              <List.Description>
+                {_truncate(licenseDescription, { length: 300 })}
+                {link && (
+                  <span>
+                    <a href={link} target="_blank" rel="noopener noreferrer">
+                      Read more
+                    </a>
+                  </span>
+                )}
+              </List.Description>
             )}
           </List.Content>
         </Ref>

--- a/src/lib/components/License/LicenseModal.js
+++ b/src/lib/components/License/LicenseModal.js
@@ -69,6 +69,7 @@ export class LicenseModal extends Component {
       title: '',
       description: '',
       id: null,
+      link: '',
     };
     const searchApi = new InvenioSearchApi(this.props.searchConfig.searchApi);
     return (


### PR DESCRIPTION
LicenseField: truncate the description 
* custom license filed 'link' check - and render the 'Read more'

closes inveniosoftware/invenio-app-rdm#530
related to https://github.com/inveniosoftware/invenio-app-rdm/pull/553

*screenshots*

![screenshot-done](https://user-images.githubusercontent.com/44528277/107352957-c5d6e680-6acc-11eb-94ec-713e92967ff2.png)
