### PR TITLE
bugfix: show readmore when no description

### DIFF
--- a/src/lib/components/License/LicenseFieldItem.js
+++ b/src/lib/components/License/LicenseFieldItem.js
@@ -97,14 +97,15 @@ export const LicenseFieldItem = ({
             {licenseDescription && (
               <List.Description>
                 {_truncate(licenseDescription, { length: 300 })}
-                {link && (
-                  <span>
-                    <a href={link} target="_blank" rel="noopener noreferrer">
-                      Read more
-                    </a>
-                  </span>
-                )}
               </List.Description>
+            )}
+            {link && (
+              <span>
+                <a href={link} target="_blank" rel="noopener noreferrer">
+                {licenseDescription && (<span>&nbsp;</span>)}
+                Read more
+                </a>
+              </span>
             )}
           </List.Content>
         </Ref>


### PR DESCRIPTION
adding space only when there is a description.

closes inveniosoftware/invenio-app-rdm#584

**screenshot**
![license-space](https://user-images.githubusercontent.com/44528277/108988345-a6c38180-7694-11eb-9215-febe9fa5065b.png)
