### PR TITLE
fileUploader: add back warning message if draft upload

### DIFF
--- a/src/lib/components/FileUploader/FileUploader.js
+++ b/src/lib/components/FileUploader/FileUploader.js
@@ -113,7 +113,19 @@ export const FileUploaderComponent = ({
           />
         </Grid.Row>
       )}
-      {!isDraftRecord && (
+      {isDraftRecord ? (
+        <Grid.Row className="file-upload-note-row">
+          <Grid.Column width={16}>
+            <Message visible warning>
+              <p>
+                <Icon name="warning sign" />
+                File addition, removal or modification are not allowed after you
+                have published your upload.
+              </p>
+            </Message>
+          </Grid.Column>
+        </Grid.Row>
+      ) : (
         <Grid.Row className="file-upload-note-row">
           <Grid.Column width={16}>
             <Message info>


### PR DESCRIPTION
closes  https://github.com/inveniosoftware/invenio-app-rdm/issues/721

<img width="1229" alt="Screenshot 2021-03-24 at 15 40 24" src="https://user-images.githubusercontent.com/22594783/112329229-4df90000-8cb7-11eb-8108-301cb27706f5.png">
<img width="1242" alt="Screenshot 2021-03-24 at 15 40 13" src="https://user-images.githubusercontent.com/22594783/112329308-60733980-8cb7-11eb-9860-584ce765a4a4.png">
