### PR TITLE
deposit-form: show warning to user if files are missing while saving draft

### DIFF
--- a/src/lib/DepositController.js
+++ b/src/lib/DepositController.js
@@ -79,16 +79,17 @@ export class DepositController {
 
     let data = recordSerializer.deserialize(response.data || {});
     let errors = recordSerializer.deserializeErrors(response.errors || []);
+    errors = this._validateDraftFiles(store.getState().files, errors);
 
     // response 100% successful
-    if ( 200 <= response.code && response.code < 300 && _isEmpty(errors) ) {
+    if (200 <= response.code && response.code < 300 && _isEmpty(errors)) {
       store.dispatch({
         type: ACTION_SAVE_SUCCEEDED,
         payload: { data },
       });
     }
     // response partially successful
-    else if (200 <= response.code && response.code < 300 ) {
+    else if (200 <= response.code && response.code < 300) {
       store.dispatch({
         type: ACTION_SAVE_PARTIALLY_SUCCEEDED,
         payload: { data, errors },
@@ -105,6 +106,22 @@ export class DepositController {
     }
 
     formik.setSubmitting(false);
+  }
+
+  _validateDraftFiles(files, errors) {
+    const filesEnabled = files.enabled;
+    const numberOfFiles = Object.values(files.entries).length;
+
+    if (filesEnabled && !numberOfFiles) {
+      return {
+        ...errors,
+        metadata: {
+          files: "Missing uploaded files. To disable files for this record please mark 'Metadata-only record' checkbox.",
+          ...errors.metadata
+        }
+      }
+    }
+    return errors;
   }
 
   /**


### PR DESCRIPTION
closes https://github.com/inveniosoftware/invenio-app-rdm/issues/736
closes https://github.com/inveniosoftware/invenio-app-rdm/issues/456
Provides some feedback to the end-user that files are missing while trying to save the draft. Result:
![pr3](https://user-images.githubusercontent.com/4990025/113303113-0ac70e80-9301-11eb-9495-b54256ee2315.gif)
