### PR TITLE
ProtectionWidget: show files section unless metadata only

### DIFF
--- a/src/lib/components/Access/EmbargoedMetadataOnly.js
+++ b/src/lib/components/Access/EmbargoedMetadataOnly.js
@@ -9,8 +9,8 @@ import { DateTime } from 'luxon';
 
 import { embargoSection, filesSection, MessageSection, MetadataSection } from './utils';
 
-// Record and files embargoed
-export class Embargoed {
+// Embargoed no files
+export class EmbargoedMetadataOnly {
   constructor(embargo) {
     this.embargo = embargo;
   }
@@ -20,12 +20,12 @@ export class Embargoed {
   }
 
   renderFilesSection() {
-    // Same as Restricted
     const filesStyle = {
       opacity: "0.5",
       cursor: "default !important"
     };
-    let filesContent = <p style={{...filesStyle, textAlign: "center"}}><em>The full record is restricted.</em></p>;
+    let filesContent = <p style={{...filesStyle, textAlign: "center"}}><em>The record has no files.</em></p>;
+
     return filesSection(filesStyle, filesContent);
   }
 
@@ -37,7 +37,7 @@ export class Embargoed {
       : "???"
     );
 
-    const text = <>On <b>{fmtDate}</b> the record and the files will automatically be made publicly accessible. Until then, the record and the files can <b>only</b> be accessed by <b>users specified</b> in the permissions.</>;
+    const text = <>On <b>{fmtDate}</b> the record will automatically be made publicly accessible. Until then, the record can <b>only</b> be accessed by <b>users specified</b> in the permissions.</>
 
     return <MessageSection
       intent={{warning: true}}

--- a/src/lib/components/Access/PublicFiles.js
+++ b/src/lib/components/Access/PublicFiles.js
@@ -1,0 +1,42 @@
+// This file is part of React-Invenio-Deposit
+// Copyright (C) 2020-2021 CERN.
+// Copyright (C) 2020-2021 Northwestern University.
+//
+// React-Invenio-Deposit is free software; you can redistribute it and/or modify it
+// under the terms of the MIT License; see LICENSE file for more details.
+import React from 'react';
+
+import { embargoSection, filesButtons, filesSection, MessageSection, MetadataSection } from './utils';
+
+// Fully public (metadata + files)
+export class PublicFiles {
+  constructor(embargo) {
+    this.embargo = embargo;
+  }
+
+  renderMetadataSection() {
+    return <MetadataSection isPublic={true} />;
+  }
+
+  renderFilesSection() {
+    let filesStyle = {};
+    let filesContent = filesButtons(true);
+    return filesSection(filesStyle, filesContent);
+  }
+
+  renderMessageSection() {
+    const text = "The record and files are publicly accessible.";
+
+    return <MessageSection
+      intent={{positive: true}}
+      icon="lock open"
+      title="Public"
+      text={text}
+    />;
+  }
+
+  renderEmbargoSection() {
+    return embargoSection(this.embargo);
+  }
+
+}

--- a/src/lib/components/Access/PublicMetadataOnly.js
+++ b/src/lib/components/Access/PublicMetadataOnly.js
@@ -6,12 +6,11 @@
 // under the terms of the MIT License; see LICENSE file for more details.
 import React from 'react';
 
-import { embargoSection, filesButtons, filesSection, MessageSection, MetadataSection } from './utils';
+import { embargoSection, filesSection, MessageSection, MetadataSection } from './utils';
 
-// Fully public (metadata + files)
-export class Public {
-  constructor(hasFiles, embargo) {
-    this.hasFiles = hasFiles;
+// Public record no files
+export class PublicMetadataOnly {
+  constructor(embargo) {
     this.embargo = embargo;
   }
 
@@ -20,28 +19,17 @@ export class Public {
   }
 
   renderFilesSection() {
-    let filesContent;
-    let filesStyle = {};
-
-    if (this.hasFiles) {
-      filesContent = filesButtons(true);
-    } else {
-      filesStyle = {
-        opacity: "0.5",
-        cursor: "default !important"
-      };
-      filesContent = <p style={{...filesStyle, textAlign: "center"}}><em>The record has no files.</em></p>;
-    }
+    let filesStyle = {
+      opacity: "0.5",
+      cursor: "default !important"
+    };
+    let filesContent = <p style={{...filesStyle, textAlign: "center"}}><em>The record has no files.</em></p>;
 
     return filesSection(filesStyle, filesContent);
   }
 
   renderMessageSection() {
-    const text = (
-      this.hasFiles
-      ? <>The record and files are publicly accessible.</>
-      : <>The record is publicly accessible.</>
-    );
+    const text = "The record is publicly accessible.";
 
     return <MessageSection
       intent={{positive: true}}

--- a/src/lib/components/Access/Restricted.js
+++ b/src/lib/components/Access/Restricted.js
@@ -8,10 +8,9 @@ import React from 'react';
 
 import { embargoSection, filesSection, MessageSection, MetadataSection } from './utils';
 
-// Fully restricted
+// Record and files restricted
 export class Restricted {
-  constructor(hasFiles, embargo) {
-    this.hasFiles = hasFiles;
+  constructor(embargo) {
     this.embargo = embargo;
   }
 
@@ -26,23 +25,12 @@ export class Restricted {
       opacity: "0.5",
       cursor: "default !important"
     };
-    let filesContent;
-    if (this.hasFiles) {
-      filesContent = <p style={{...filesStyle, textAlign: "center"}}><em>The full record is set to restricted.</em></p>;
-    } else {
-      filesContent = <p style={{...filesStyle, textAlign: "center"}}><em>The record has no files.</em></p>;
-    }
-
+    let filesContent = <p style={{...filesStyle, textAlign: "center"}}><em>The full record is restricted.</em></p>;
     return filesSection(filesStyle, filesContent);
   }
 
   renderMessageSection() {
-    const text = (
-      this.hasFiles
-      // TODO: record / record and the files can be DRYed
-      ? <>The record and files can <b>only</b> be accessed by <b>users specified</b> in the permissions.</>
-      : <>The record can <b>only</b> be accessed by <b>users specified</b> in the permissions.</>
-    );
+    const text = <>The record and files can <b>only</b> be accessed by <b>users specified</b> in the permissions.</>;
 
     return <MessageSection
       intent={{negative: true}}

--- a/src/lib/components/Access/RestrictedMetadataOnly.js
+++ b/src/lib/components/Access/RestrictedMetadataOnly.js
@@ -5,49 +5,44 @@
 // React-Invenio-Deposit is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
 import React from 'react';
-import { DateTime } from 'luxon';
 
 import { embargoSection, filesSection, MessageSection, MetadataSection } from './utils';
 
-// Record and files embargoed
-export class Embargoed {
+// Restricted no files
+export class RestrictedMetadataOnly {
   constructor(embargo) {
     this.embargo = embargo;
   }
 
   renderMetadataSection() {
+    // Same as embargoed
     return <MetadataSection isPublic={false} />;
   }
 
   renderFilesSection() {
-    // Same as Restricted
+    // Same as embargoed
     const filesStyle = {
       opacity: "0.5",
       cursor: "default !important"
     };
-    let filesContent = <p style={{...filesStyle, textAlign: "center"}}><em>The full record is restricted.</em></p>;
+    let filesContent = <p style={{...filesStyle, textAlign: "center"}}><em>The record has no files.</em></p>;
     return filesSection(filesStyle, filesContent);
   }
 
   renderMessageSection() {
-    const fmtDate = (
-      this.embargo.date
-      ? DateTime.fromISO(this.embargo.date)
-        .toLocaleString(DateTime.DATE_FULL) // e.g. June 21, 2021
-      : "???"
-    );
-
-    const text = <>On <b>{fmtDate}</b> the record and the files will automatically be made publicly accessible. Until then, the record and the files can <b>only</b> be accessed by <b>users specified</b> in the permissions.</>;
+    const text = <>The record can <b>only</b> be accessed by <b>users specified</b> in the permissions.</>;
 
     return <MessageSection
-      intent={{warning: true}}
+      intent={{negative: true}}
       icon="lock"
-      title="Embargoed (full record)"
+      title="Restricted"
       text={text}
     />;
+
   }
 
   renderEmbargoSection() {
+    // Same as Embargoed, same as Public
     return embargoSection(this.embargo);
   }
 

--- a/src/lib/components/Access/index.js
+++ b/src/lib/components/Access/index.js
@@ -8,6 +8,9 @@
 export { Embargo, EmbargoState } from './Embargo';
 export { Embargoed } from './Embargoed';
 export { EmbargoedFiles } from './EmbargoedFiles';
-export { Public } from './Public';
+export { EmbargoedMetadataOnly } from './EmbargoedMetadataOnly';
+export { PublicFiles } from './PublicFiles';
+export { PublicMetadataOnly } from './PublicMetadataOnly';
 export { Restricted } from './Restricted';
 export { RestrictedFiles } from './RestrictedFiles';
+export { RestrictedMetadataOnly } from './RestrictedMetadataOnly';

--- a/src/lib/components/FileUploader/FileUploaderToolbar.js
+++ b/src/lib/components/FileUploader/FileUploaderToolbar.js
@@ -30,11 +30,8 @@ export const FileUploaderToolbar = ({
             <List.Item>
               <Checkbox
                 label={'Metadata-only record'}
-                onClick={(event, data) => {
-                  if (!data['disabled']) {
-                    // if checkbox is not disabled
-                    setFilesEnabled(formikDraft, !filesEnabled);
-                  }
+                onChange={(event, data) => {  // onChange accounts for disabled
+                  setFilesEnabled(formikDraft, !filesEnabled);
                 }}
                 disabled={filesList.length > 0}
                 checked={!filesEnabled}


### PR DESCRIPTION
closes https://github.com/inveniosoftware/invenio-app-rdm/issues/740

Screenshot

![protection_files_enabled_non_metadata_only](https://user-images.githubusercontent.com/1932651/113597256-0c464e80-9601-11eb-89b0-1a8df0b2fbf0.png)
