### PR TITLE
SaveButton: scroll to top after saved

### DIFF
--- a/src/lib/components/SaveButton.js
+++ b/src/lib/components/SaveButton.js
@@ -20,11 +20,20 @@ export class SaveButtonComponent extends Component {
   render() {
     const { formState, saveClick, ...uiProps } = this.props;
 
+    function handleClick(e, formik) {
+      saveClick(e, formik);
+      window.scrollTo({
+        top: 0,
+        left: 0,
+        behavior: 'smooth'
+      });
+    }
+
     return (
       <ActionButton
         isDisabled={this.isDisabled}
         name="save"
-        onClick={saveClick}
+        onClick={handleClick}
         icon
         labelPosition="left"
         {...uiProps}


### PR DESCRIPTION
**Edit May 12 2021**
Thanks to @zzacharo + @ntarocco : now using `scrollTo` (I was looking at `scroll` before https://developer.mozilla.org/en-US/docs/Web/API/Window/scroll and lamenting the Safari lack of support :facepalm: ). Though it would be good for someone with Safari to doublecheck it. (below is new video on Firefox). No other dependencies.

- closes https://github.com/inveniosoftware/react-invenio-deposit/issues/281


https://user-images.githubusercontent.com/1932651/117978899-59a09480-b300-11eb-8074-2b935e35ebfb.mp4

