### PR TITLE
creatibutors: fix modal bug

### DIFF
--- a/src/lib/components/Creatibutors/CreatibutorsModal.js
+++ b/src/lib/components/Creatibutors/CreatibutorsModal.js
@@ -171,6 +171,10 @@ export class CreatibutorsModal extends Component {
     formikBag.resetForm();
     switch (this.state.action) {
       case 'saveAndContinue':
+        // Needed to close and open the modal to reset the internal
+        // state of the cmp inside the modal
+        this.closeModal();
+        this.openModal();
         this.changeContent();
         break;
       case 'saveAndClose':


### PR DESCRIPTION
- closes https://github.com/inveniosoftware/invenio-app-rdm/issues/960
* reopens modal when saving and adding
  another one to unmount and mount again
  the components and reset their state

### Before
https://user-images.githubusercontent.com/15194802/123294630-514d9300-d515-11eb-889e-b479088ccb50.mp4

### After
https://user-images.githubusercontent.com/15194802/123294634-527ec000-d515-11eb-9500-b680db6659a2.mp4

