### PR TITLE
license: use 'Search' as placeholder

### DIFF
--- a/src/lib/components/License/LicenseModal.js
+++ b/src/lib/components/License/LicenseModal.js
@@ -120,6 +120,7 @@ export class LicenseModal extends Component {
                         verticalAlign="middle"
                       >
                         <SearchBar
+                          placeholder={i18next.t('Search')}
                           autofocus
                           actionProps={{
                             icon: 'search',


### PR DESCRIPTION
closes https://github.com/inveniosoftware/invenio-app-rdm/issues/1017


![license_search](https://user-images.githubusercontent.com/1932651/127217544-43b49480-391e-404a-83a9-f290ede305aa.png)
