### PR TITLE
ActionButton: align label to center

### DIFF
--- a/src/lib/components/PreviewButton.js
+++ b/src/lib/components/PreviewButton.js
@@ -67,7 +67,7 @@ export class PreviewButtonComponent extends Component {
           });
         }}
         icon
-        labelPosition="left"
+        labelPosition="center"
         {...uiProps}
       >
         {(formik) => (

--- a/src/lib/components/SaveButton.js
+++ b/src/lib/components/SaveButton.js
@@ -37,7 +37,7 @@ export class SaveButtonComponent extends Component {
         name="save"
         onClick={handleClick}
         icon
-        labelPosition="left"
+        labelPosition="center"
         {...uiProps}
       >
         {(formik) => (


### PR DESCRIPTION
closes inveniosoftware/invenio-app-rdm#1012
The labels for SaveButton & PreviewButtons are now align to the center.
![i-1012-en](https://user-images.githubusercontent.com/44528277/127491864-d9d0360b-b75b-44aa-9ae1-1ab9c804e212.png)
![i-1012-de](https://user-images.githubusercontent.com/44528277/127491865-5d1b9e64-3e78-421a-93da-f037cc12e2f3.png)

