### PR TITLE
ORCID icon: size fixed

### DIFF
--- a/src/lib/components/Creatibutors/CreatibutorsFieldItem.js
+++ b/src/lib/components/Creatibutors/CreatibutorsFieldItem.js
@@ -110,7 +110,7 @@ export const CreatibutorsFieldItem = ({
               {_get(initialCreatibutor, 'person_or_org.identifiers', []).some(
                 (identifier) => identifier.scheme === 'orcid'
               ) && (
-                <img className="inline-orcid" src="/static/images/orcid.svg" />
+                <img className="inline-id-icon" src="/static/images/orcid.svg" />
               )}
               {displayName} {renderRole(initialCreatibutor?.role, roleOptions)}
             </List.Description>

--- a/src/lib/components/Creatibutors/CreatibutorsFieldItem.js
+++ b/src/lib/components/Creatibutors/CreatibutorsFieldItem.js
@@ -1,6 +1,7 @@
 // This file is part of React-Invenio-Deposit
 // Copyright (C) 2021 CERN.
 // Copyright (C) 2021 Northwestern University.
+// Copyright (C) 2021 New York University.
 //
 // React-Invenio-Deposit is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.

--- a/src/lib/components/Creatibutors/CreatibutorsFieldItem.js
+++ b/src/lib/components/Creatibutors/CreatibutorsFieldItem.js
@@ -110,7 +110,7 @@ export const CreatibutorsFieldItem = ({
               {_get(initialCreatibutor, 'person_or_org.identifiers', []).some(
                 (identifier) => identifier.scheme === 'orcid'
               ) && (
-                <img className="inline-id-icon" src="/static/images/orcid.svg" />
+                <img className="inline-id-icon" src="/static/images/orcid.svg" width="16" height="16" />
               )}
               {displayName} {renderRole(initialCreatibutor?.role, roleOptions)}
             </List.Description>

--- a/src/lib/components/Creatibutors/CreatibutorsFieldItem.js
+++ b/src/lib/components/Creatibutors/CreatibutorsFieldItem.js
@@ -110,7 +110,7 @@ export const CreatibutorsFieldItem = ({
               {_get(initialCreatibutor, 'person_or_org.identifiers', []).some(
                 (identifier) => identifier.scheme === 'orcid'
               ) && (
-                <img className="inline-id-icon" src="/static/images/orcid.svg" width="16" height="16" />
+                <img alt="ORCID logo" className="inline-id-icon" src="/static/images/orcid.svg" width="16" height="16" />
               )}
               {displayName} {renderRole(initialCreatibutor?.role, roleOptions)}
             </List.Description>

--- a/src/lib/components/Creatibutors/CreatibutorsFieldItem.js
+++ b/src/lib/components/Creatibutors/CreatibutorsFieldItem.js
@@ -107,12 +107,14 @@ export const CreatibutorsFieldItem = ({
         <Ref innerRef={preview}>
           <List.Content>
             <List.Description>
+              <span class="creatibutor">
               {_get(initialCreatibutor, 'person_or_org.identifiers', []).some(
                 (identifier) => identifier.scheme === 'orcid'
               ) && (
                 <img alt="ORCID logo" className="inline-id-icon" src="/static/images/orcid.svg" width="16" height="16" />
               )}
               {displayName} {renderRole(initialCreatibutor?.role, roleOptions)}
+              </span>
             </List.Description>
             {firstError && (
               <Label pointing="left" prompt>


### PR DESCRIPTION
This PR addresses this bug: https://github.com/inveniosoftware/invenio-app-rdm/issues/1144

- Standardizes classname (with rest of site)
- hardcodes width and height to meet ORCID's branding guidelines
- Alt tag for a11y
- Adds span tag wrapper for ease of styling