### PR TITLE
FileUploader: add option to switch file size display style

### DIFF
--- a/src/lib/components/FileUploader/FileUploader.js
+++ b/src/lib/components/FileUploader/FileUploader.js
@@ -1,7 +1,8 @@
 // This file is part of React-Invenio-Deposit
 // Copyright (C) 2020-2022 CERN.
 // Copyright (C) 2020-2022 Northwestern University.
-// Copyright (C) 2022 Graz University of Technology.
+// Copyright (C)      2022 Graz University of Technology.
+// Copyright (C)      2022 TU Wien.
 //
 // React-Invenio-Deposit is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
@@ -35,6 +36,7 @@ export const FileUploaderComponent = ({
   importButtonIcon,
   importButtonText,
   isFileImportInProgress,
+  decimalSizeDisplay,
   ...uiProps
 }) => {
   // We extract the working copy of the draft stored as `values` in formik
@@ -105,9 +107,12 @@ export const FileUploaderComponent = ({
               content={
                 <>
                   {i18next.t('Uploading the selected files would result in')}{' '}
-                  {humanReadableBytes(filesSize + acceptedFilesSize)}
+                  {humanReadableBytes(
+                    filesSize + acceptedFilesSize,
+                    decimalSizeDisplay
+                  )}
                   {i18next.t('but the limit is')}
-                  {humanReadableBytes(quota.maxStorage)}.
+                  {humanReadableBytes(quota.maxStorage, decimalSizeDisplay)}.
                 </>
               }
             />
@@ -155,6 +160,7 @@ export const FileUploaderComponent = ({
               filesSize={filesSize}
               isDraftRecord={isDraftRecord}
               quota={quota}
+              decimalSizeDisplay={decimalSizeDisplay}
             />
           )}
         </Grid.Row>
@@ -191,6 +197,7 @@ export const FileUploaderComponent = ({
               isDraftRecord={isDraftRecord}
               filesEnabled={filesEnabled}
               deleteFile={deleteFile}
+              decimalSizeDisplay={decimalSizeDisplay}
             />
           </Grid.Row>
         )}
@@ -272,6 +279,7 @@ FileUploaderComponent.propTypes = {
   importParentFiles: PropTypes.func,
   uploadFiles: PropTypes.func,
   deleteFile: PropTypes.func,
+  decimalSizeDisplay: PropTypes.bool,
 };
 
 FileUploaderComponent.defaultProps = {
@@ -286,4 +294,5 @@ FileUploaderComponent.defaultProps = {
   uploadButtonText: i18next.t('Upload files'),
   importButtonIcon: 'sync',
   importButtonText: i18next.t('Import files'),
+  decimalSizeDisplay: true,
 };

--- a/src/lib/components/FileUploader/FileUploaderArea.js
+++ b/src/lib/components/FileUploader/FileUploaderArea.js
@@ -2,6 +2,7 @@
 // Copyright (C) 2020-2022 CERN.
 // Copyright (C) 2020-2022 Northwestern University.
 // Copyright (C) 2021-2022 Graz University of Technology.
+// Copyright (C)      2022 TU Wien.
 //
 // React-Invenio-Deposit is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
@@ -114,7 +115,7 @@ const FileTableRow = ({
         )}
       </Table.Cell>
       <Table.Cell className="file-table-cell" width={2}>
-        {file.size ? humanReadableBytes(file.size) : ''}
+        {file.size ? humanReadableBytes(file.size, decimalSizeDisplay) : ''}
       </Table.Cell>
       {isDraftRecord && (
         <Table.Cell className="file-table-cell file-upload-pending" width={2}>
@@ -208,7 +209,12 @@ const FileUploadBox = ({
     </Segment>
   );
 
-const FilesListTable = ({ isDraftRecord, filesList, deleteFile }) => {
+const FilesListTable = ({
+  isDraftRecord,
+  filesList,
+  deleteFile,
+  decimalSizeDisplay,
+}) => {
   const { setFieldValue, values: formikDraft } = useFormikContext();
   const defaultPreview = _get(formikDraft, 'files.default_preview', '');
   return (
@@ -226,6 +232,7 @@ const FilesListTable = ({ isDraftRecord, filesList, deleteFile }) => {
               setDefaultPreview={(filename) =>
                 setFieldValue('files.default_preview', filename)
               }
+              decimalSizeDisplay={decimalSizeDisplay}
             />
           );
         })}
@@ -282,4 +289,5 @@ FileUploaderArea.propTypes = {
   setDefaultPreviewFile: PropTypes.func,
   uploadButtonIcon: PropTypes.string,
   uploadButtonText: PropTypes.string,
+  decimalSizeDisplay: PropTypes.bool,
 };

--- a/src/lib/components/FileUploader/FileUploaderToolbar.js
+++ b/src/lib/components/FileUploader/FileUploaderToolbar.js
@@ -1,7 +1,8 @@
 // This file is part of React-Invenio-Deposit
 // Copyright (C) 2020-2021 CERN.
 // Copyright (C) 2020-2021 Northwestern University.
-// Copyright (C) 2021 Graz University of Technology.
+// Copyright (C)      2021 Graz University of Technology.
+// Copyright (C)      2022 TU Wien.
 //
 // React-Invenio-Deposit is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
@@ -19,6 +20,7 @@ export const FileUploaderToolbar = ({
   filesSize,
   filesEnabled,
   quota,
+  decimalSizeDisplay,
 }) => {
   const { setFieldValue } = useFormikContext();
 
@@ -37,9 +39,7 @@ export const FileUploaderToolbar = ({
             </List.Item>
             <List.Item>
               <Popup
-                trigger={
-                  <Icon name="question circle outline" color="grey"/>
-                }
+                trigger={<Icon name="question circle outline" color="grey" />}
                 content={i18next.t('Disable files for this record')}
                 position="top center"
               />
@@ -65,13 +65,14 @@ export const FileUploaderToolbar = ({
             </List.Item>
             <List.Item>
               <Label
-                {...(humanReadableBytes(filesSize) ===
-                humanReadableBytes(quota.maxStorage)
+                {...(humanReadableBytes(filesSize, decimalSizeDisplay) ===
+                humanReadableBytes(quota.maxStorage, decimalSizeDisplay)
                   ? { color: 'blue' }
                   : {})}
               >
-                {humanReadableBytes(filesSize)} {i18next.t('out of')}{' '}
-                {humanReadableBytes(quota.maxStorage)}
+                {humanReadableBytes(filesSize, decimalSizeDisplay)}{' '}
+                {i18next.t('out of')}{' '}
+                {humanReadableBytes(quota.maxStorage, decimalSizeDisplay)}
               </Label>
             </List.Item>
           </List>

--- a/src/lib/components/FileUploader/utils.js
+++ b/src/lib/components/FileUploader/utils.js
@@ -1,6 +1,7 @@
 // This file is part of React-Invenio-Deposit
 // Copyright (C) 2020 CERN.
 // Copyright (C) 2020 Northwestern University.
+// Copyright (C) 2022 TU Wien.
 //
 // React-Invenio-Deposit is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
@@ -9,20 +10,33 @@ import React from 'react';
 
 import _isNumber from 'lodash/isNumber';
 
-export function humanReadableBytes(bytes) {
+export function humanReadableBytes(bytes, decimalDisplay = false) {
   if (_isNumber(bytes)) {
-    const kiloBytes = 1000;
-    const megaBytes = 1000 * kiloBytes;
-    const gigaBytes = 1000 * megaBytes;
+    const base = decimalDisplay ? 1000 : 1024;
+    const kiloBytes = base;
+    const megaBytes = base * kiloBytes;
+    const gigaBytes = base * megaBytes;
 
     if (bytes < kiloBytes) {
       return <>{bytes} bytes</>;
     } else if (bytes < megaBytes) {
-      return <>{(bytes / kiloBytes).toFixed(2)} Kb</>;
+      return (
+        <>
+          {(bytes / kiloBytes).toFixed(2)} {decimalDisplay ? 'KB' : 'KiB'}
+        </>
+      );
     } else if (bytes < gigaBytes) {
-      return <>{(bytes / megaBytes).toFixed(2)} Mb</>;
+      return (
+        <>
+          {(bytes / megaBytes).toFixed(2)} {decimalDisplay ? 'MB' : 'MiB'}
+        </>
+      );
     } else {
-      return <>{(bytes / gigaBytes).toFixed(2)} Gb</>;
+      return (
+        <>
+          {(bytes / gigaBytes).toFixed(2)} {decimalDisplay ? 'GB' : 'GiB'}
+        </>
+      );
     }
   }
   return '';


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Until now, the file sizes were always displayed in decimal format, i.e. powers of 1000 (KB, MB, GB) instead of binary format, i.e. powers of 1024 (KiB, MiB, GiB), which could be potentially incongruent with the configuration of the back-end (where usually, but not necessarily, binary file sizes are specified).
This PR enables the option to switch between decimal and binary file sizes, as desired. 

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code).
- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
