### PR TITLE
License header has invalid size 'mt-0'

### DIFF
--- a/src/lib/components/License/LicenseResults.js
+++ b/src/lib/components/License/LicenseResults.js
@@ -48,7 +48,7 @@ export const LicenseResults = withState(
                     }
                   />
                   <Item.Content className="license-item-content">
-                    <Header size="small mt-0">{title}</Header>
+                    <Header size="small" className="mt-0">{title}</Header>
                     <Item.Description className="license-item-description">
                       {description}
                     </Item.Description>


### PR DESCRIPTION
This PR fixes an issue with `LicenseResults` component. The item's `Header` has a property `size` which accepts `small` as a value. Nonetheless, `small mt-0` is being passed which yields the following warning:


```
Warning: Failed prop type: Invalid prop `size` of value `small mt-0` supplied to `Header`, expected one of ["tiny", "small", ...] 
```

 