### PR TITLE
Add GND and ROR icons to creatibutor entries

### DIFF
--- a/src/lib/components/Creatibutors/CreatibutorsFieldItem.js
+++ b/src/lib/components/Creatibutors/CreatibutorsFieldItem.js
@@ -116,8 +116,30 @@ export const CreatibutorsFieldItem = ({
                 ) && (
                   <img
                     alt="ORCID logo"
-                    className="inline-id-icon"
+                    className="inline-id-icon mr-5"
                     src="/static/images/orcid.svg"
+                    width="16"
+                    height="16"
+                  />
+                )}
+                {_get(initialCreatibutor, 'person_or_org.identifiers', []).some(
+                  (identifier) => identifier.scheme === 'ror'
+                ) && (
+                  <img
+                    alt="ROR logo"
+                    className="inline-id-icon mr-5"
+                    src="/static/images/ror-icon.svg"
+                    width="16"
+                    height="16"
+                  />
+                )}
+                {_get(initialCreatibutor, 'person_or_org.identifiers', []).some(
+                  (identifier) => identifier.scheme === 'gnd'
+                ) && (
+                  <img
+                    alt="GND logo"
+                    className="inline-id-icon mr-5"
+                    src="/static/images/gnd-icon.svg"
                     width="16"
                     height="16"
                   />


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description
Adds GND and ROR icons next to creatibutors with these identifers set (presently only ORCID icon displayed):

![Screenshot 2022-04-27 at 15 50 02](https://user-images.githubusercontent.com/7934352/165547271-c8eb9171-d514-4a8c-b3e4-6872b77efce5.png)

Note this depends on the GND icon added in invenio-app-rdm#1470

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code).
- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
