### PR TITLE
community header: make logo-image size mini

### DIFF
--- a/src/lib/components/Communities/CommunityHeader.js
+++ b/src/lib/components/Communities/CommunityHeader.js
@@ -34,6 +34,7 @@ class CommunityHeaderComponent extends Component {
               <>
                 <div className="page-subheader-element">
                   <Image
+                    size="mini"
                     className="community-logo-header"
                     src={community.links?.logo || imagePlaceholderLink} // logo is undefined when new draft and no selection
                     fallbackSrc={imagePlaceholderLink}


### PR DESCRIPTION
## Screenshot
![Screenshot 2022-05-12 at 13 50 56](https://user-images.githubusercontent.com/21052053/168069040-dd457054-6319-47dc-be9d-2fca7c80d63a.png)
