### PR TITLE
community selection modal: make triggerbutton customizable

### DIFF
--- a/src/lib/components/Communities/CommunityHeader.js
+++ b/src/lib/components/Communities/CommunityHeader.js
@@ -59,7 +59,20 @@ class CommunityHeaderComponent extends Component {
                       changeSelectedCommunity(community);
                     }}
                     chosenCommunity={community}
-                    disableTriggerButton={disableCommunitySelectionButton}
+                    trigger={
+                      <Button
+                        className="community-header-button"
+                        disabled={disableCommunitySelectionButton}
+                        primary={true}
+                        size="mini"
+                        name="setting"
+                        type="button"
+                        content={community 
+                          ? i18next.t('Change') 
+                          : i18next.t('Select a community')
+                        }
+                      />
+                    }
                   />
                   {community && (
                     <Button

--- a/src/lib/components/CommunitySelectionModal/CommunitySelectionModal.js
+++ b/src/lib/components/CommunitySelectionModal/CommunitySelectionModal.js
@@ -35,7 +35,7 @@ export class CommunitySelectionModal extends Component {
 
   render() {
     const { modalOpen, localChosenCommunity } = this.state;
-    const { chosenCommunity, disableTriggerButton } = this.props;
+    const { chosenCommunity, trigger } = this.props;
 
     return (
       <CommunityContext.Provider value={this.contextValue}>
@@ -55,20 +55,10 @@ export class CommunitySelectionModal extends Component {
             })
           }
           trigger={
-            <Button
-              primary
-              size="mini"
-              className="community-header-button"
-              name="setting"
-              type="button"
-              disabled={disableTriggerButton}
-              aria-haspopup="dialog"
-              aria-expanded={modalOpen}
-            >
-              {chosenCommunity
-                ? i18next.t('Change')
-                : i18next.t('Select a community')}
-            </Button>
+            React.cloneElement(trigger, {
+              'aria-haspopup': "dialog",
+              'aria-expanded': modalOpen
+            })
           }
         >
           <Modal.Header>
@@ -89,7 +79,7 @@ export class CommunitySelectionModal extends Component {
 CommunitySelectionModal.propTypes = {
   chosenCommunity: PropTypes.object,
   onCommunityChange: PropTypes.func.isRequired,
-  disableTriggerButton: PropTypes.bool.isRequired,
+  trigger: PropTypes.object.isRequired,
 };
 
 CommunitySelectionModal.defaultProps = {

--- a/src/lib/components/PublishButton/SubmitReviewOrPublishButton.js
+++ b/src/lib/components/PublishButton/SubmitReviewOrPublishButton.js
@@ -34,12 +34,17 @@ class SubmitReviewOrPublishComponent extends Component {
     ) : showChangeCommunityButton ? (
       <>
         <CommunitySelectionModal
-          className="mb-5"
           onCommunityChange={(community) => {
             changeSelectedCommunity(community);
           }}
           chosenCommunity={community}
-          trigger={<Button fluid>{i18next.t('Change community')}</Button>}
+          trigger={
+            <Button
+              content={i18next.t("Change community")}
+              fluid={true}
+              className="mb-10"
+            />
+          }
         />
         <PublishButton
           buttonLabel={i18next.t('Publish without community')}


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/1566

Changed the `CommunitySelectionModal` to take custom props for the trigger-button. 

The reason for doing this instead of passing a custom `<Button/>` to a `trigger`-prop of the module, is because it otherwise makes it more complicated to update the aria-attributes of the button when the modal opens/closes.

## Screenshots
![Screenshot 2022-05-13 at 16 12 35](https://user-images.githubusercontent.com/21052053/168304333-e339c515-2144-4dbb-882d-b6766fa2befd.png)
![Screenshot 2022-05-13 at 16 12 23](https://user-images.githubusercontent.com/21052053/168304341-aad9baca-9e2a-46b1-99e7-7e2dfb3507a8.png)
![Screenshot 2022-05-13 at 16 12 15](https://user-images.githubusercontent.com/21052053/168304344-83213e11-0522-4f03-8262-50ce5b140d3f.png)