### PR TITLE
fix: remove compact class from community header

### DIFF
--- a/src/lib/components/Communities/CommunityHeader.js
+++ b/src/lib/components/Communities/CommunityHeader.js
@@ -28,7 +28,7 @@ class CommunityHeaderComponent extends Component {
 
     return (
       showCommunityHeader && (
-        <Container className="page-subheader-outer compact" fluid>
+        <Container className="page-subheader-outer" fluid>
           <Container className="page-subheader">
             {community ? (
               <>


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description
closes https://github.com/inveniosoftware/invenio-app-rdm/issues/1681

Removes `compact` class from community header so community image can fit and does not overflow.
![Screenshot from 2022-05-31 16-30-42](https://user-images.githubusercontent.com/72449192/171199284-40615465-cd8b-4253-934c-94ddf10bc0af.png)


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code).
- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
