### PR TITLE
action buttons: refactor

### DIFF
--- a/src/lib/components/Creatibutors/CreatibutorsModal.js
+++ b/src/lib/components/Creatibutors/CreatibutorsModal.js
@@ -8,10 +8,9 @@
 
 import React, { Component, createRef } from 'react';
 import PropTypes from 'prop-types';
-import { Form, Grid, Header, Icon, Modal } from 'semantic-ui-react';
+import {Button, Form, Grid, Header, Icon, Modal} from 'semantic-ui-react';
 import { Formik } from 'formik';
 import {
-  ActionButton,
   Image,
   SelectField,
   TextField,
@@ -346,7 +345,7 @@ export class CreatibutorsModal extends Component {
         validateOnChange={false}
         validateOnBlur={false}
       >
-        {({ values, resetForm }) => {
+        {({ values, resetForm, handleSubmit }) => {
           const personOrOrgPath = `person_or_org`;
           const typeFieldPath = `${personOrOrgPath}.type`;
           const familyNameFieldPath = `${personOrOrgPath}.family_name`;
@@ -524,10 +523,10 @@ export class CreatibutorsModal extends Component {
                 </Form>
               </Modal.Content>
               <Modal.Actions>
-                <ActionButton
+                <Button
                   name="cancel"
-                  onClick={(values, formikBag) => {
-                    formikBag.resetForm();
+                  onClick={() => {
+                    resetForm();
                     this.closeModal();
                   }}
                   icon="remove"
@@ -535,9 +534,9 @@ export class CreatibutorsModal extends Component {
                   floated="left"
                 />
                 {this.props.action === ModalActions.ADD && (
-                  <ActionButton
+                  <Button
                     name="submit"
-                    onClick={(event, formik) => {
+                    onClick={() => {
                       this.setState(
                         {
                           action: 'saveAndContinue',
@@ -546,7 +545,7 @@ export class CreatibutorsModal extends Component {
                             NamesAutocompleteOptions.SEARCH_ONLY,
                         },
                         () => {
-                          formik.handleSubmit();
+                          handleSubmit();
                         }
                       );
                     }}
@@ -555,9 +554,9 @@ export class CreatibutorsModal extends Component {
                     content={this.state.saveAndContinueLabel}
                   />
                 )}
-                <ActionButton
+                <Button
                   name="submit"
-                  onClick={(event, formik) => {
+                  onClick={() => {
                     this.setState(
                       {
                         action: 'saveAndClose',
@@ -565,7 +564,7 @@ export class CreatibutorsModal extends Component {
                           this.props.autocompleteNames !==
                           NamesAutocompleteOptions.SEARCH_ONLY,
                       },
-                      () => formik.handleSubmit()
+                      () => handleSubmit()
                     );
                   }}
                   primary

--- a/src/lib/components/Funding/FundingModal.js
+++ b/src/lib/components/Funding/FundingModal.js
@@ -9,7 +9,6 @@ import { i18next } from '@translations/i18next';
 import { Formik } from 'formik';
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
-import { ActionButton } from 'react-invenio-forms';
 import {
   EmptyResults,
   Error,
@@ -19,7 +18,7 @@ import {
   ResultsLoader,
   SearchBar,
 } from 'react-searchkit';
-import { Grid, Modal, Container } from 'semantic-ui-react';
+import {Grid, Modal, Container, Button} from 'semantic-ui-react';
 import * as Yup from 'yup';
 import { AwardResults } from './AwardResults';
 import CustomAwardForm from './CustomAwardForm';
@@ -142,7 +141,7 @@ function FundingModal({
       validateOnBlur={false}
       enableReinitialize={true}
     >
-      {({ values, resetForm }) => (
+      {({ values, resetForm, handleSubmit }) => (
         <Modal
           role="dialog"
           centered={false}
@@ -229,19 +228,17 @@ function FundingModal({
             )}
           </Modal.Content>
           <Modal.Actions>
-            <ActionButton
-              name="cancel"
-              onClick={(values, formikBag) => {
-                formikBag.resetForm();
+            <Button
+              onClick={() => {
+                resetForm();
                 closeModal();
               }}
               icon="remove"
               content={i18next.t('Cancel')}
               floated="left"
             />
-            <ActionButton
-              name="submit"
-              onClick={(event, formik) => formik.handleSubmit(event)}
+            <Button
+              onClick={(event) => handleSubmit(event)}
               primary
               icon="checkmark"
               content={

--- a/src/lib/components/License/LicenseModal.js
+++ b/src/lib/components/License/LicenseModal.js
@@ -10,7 +10,7 @@ import { i18next } from '@translations/i18next';
 import { Formik } from 'formik';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { ActionButton, TextAreaField, TextField } from 'react-invenio-forms';
+import { TextAreaField, TextField } from 'react-invenio-forms';
 import { OverridableContext } from 'react-overridable';
 import {
   EmptyResults,
@@ -21,7 +21,7 @@ import {
   SearchBar,
   Toggle,
 } from 'react-searchkit';
-import { Form, Grid, Header, Menu, Modal } from 'semantic-ui-react';
+import { Button, Form, Grid, Header, Menu, Modal } from 'semantic-ui-react';
 import * as Yup from 'yup';
 import { LicenseFilter } from './LicenseFilter';
 import { LicenseResults } from './LicenseResults';
@@ -86,143 +86,151 @@ export class LicenseModal extends Component {
         validateOnChange={false}
         validateOnBlur={false}
       >
-        <Modal
-          onOpen={() => this.openModal()}
-          open={this.state.open}
-          trigger={this.props.trigger}
-          onClose={this.closeModal}
-          closeIcon={true}
-          closeOnDimmerClick={false}
-        >
-          <Modal.Header as="h6" className="pt-10 pb-10">
-            <Grid>
-              <Grid.Column floated="left">
-                <Header as="h2">
-                  {this.props.action === ModalActions.ADD
-                    ? i18next.t(`Add {{mode}} license`, {
-                        mode: this.props.mode,
-                      })
-                    : i18next.t(`Change {{mode}} license`, {
-                        mode: this.props.mode,
-                      })}
-                </Header>
-              </Grid.Column>
-            </Grid>
-          </Modal.Header>
-          <Modal.Content scrolling>
-            {this.props.mode === ModalTypes.STANDARD && (
-              <OverridableContext.Provider value={overriddenComponents}>
-                <ReactSearchKit
-                  searchApi={searchApi}
-                  appName={'licenses'}
-                  urlHandlerApi={{ enabled: false }}
-                  initialQueryState={this.props.searchConfig.initialQueryState}
-                >
-                  <Grid>
-                    <Grid.Row>
-                      <Grid.Column
-                        width={8}
-                        floated="left"
-                        verticalAlign="middle"
-                      >
-                        <SearchBar
-                          placeholder={i18next.t('Search')}
-                          autofocus
-                          actionProps={{
-                            icon: 'search',
-                            content: null,
-                            className: 'search',
-                          }}
-                        />
-                      </Grid.Column>
-                      <Grid.Column width={8} textAlign="right" floated="right">
-                        <Menu compact>
-                          <Toggle
-                            title={i18next.t('Recommended')}
-                            label="recommended"
-                            filterValue={['tags', 'recommended']}
+        {({ handleSubmit, resetForm }) => (
+          <Modal
+            onOpen={() => this.openModal()}
+            open={this.state.open}
+            trigger={this.props.trigger}
+            onClose={this.closeModal}
+            closeIcon={true}
+            closeOnDimmerClick={false}
+          >
+            <Modal.Header as="h6" className="pt-10 pb-10">
+              <Grid>
+                <Grid.Column floated="left">
+                  <Header as="h2">
+                    {this.props.action === ModalActions.ADD
+                      ? i18next.t(`Add {{mode}} license`, {
+                          mode: this.props.mode,
+                        })
+                      : i18next.t(`Change {{mode}} license`, {
+                          mode: this.props.mode,
+                        })}
+                  </Header>
+                </Grid.Column>
+              </Grid>
+            </Modal.Header>
+            <Modal.Content scrolling>
+              {this.props.mode === ModalTypes.STANDARD && (
+                <OverridableContext.Provider value={overriddenComponents}>
+                  <ReactSearchKit
+                    searchApi={searchApi}
+                    appName={'licenses'}
+                    urlHandlerApi={{ enabled: false }}
+                    initialQueryState={
+                      this.props.searchConfig.initialQueryState
+                    }
+                  >
+                    <Grid>
+                      <Grid.Row>
+                        <Grid.Column
+                          width={8}
+                          floated="left"
+                          verticalAlign="middle"
+                        >
+                          <SearchBar
+                            placeholder={i18next.t('Search')}
+                            autofocus
+                            actionProps={{
+                              icon: 'search',
+                              content: null,
+                              className: 'search',
+                            }}
                           />
-                          <Toggle
-                            title={i18next.t('All')}
-                            label="all"
-                            filterValue={['tags', 'all']}
-                          />
-                          <Toggle
-                            title={i18next.t('Data')}
-                            label="data"
-                            filterValue={['tags', 'data']}
-                          />
-                          <Toggle
-                            title={i18next.t('Software')}
-                            label="software"
-                            filterValue={['tags', 'software']}
-                          />
-                        </Menu>
-                      </Grid.Column>
-                    </Grid.Row>
-                    <Grid.Row verticalAlign="middle">
-                      <Grid.Column>
-                        <ResultsLoader>
-                          <EmptyResults />
-                          <Error />
-                          <LicenseResults
-                            {...(this.props.serializeLicenses && {
-                              serializeLicenses: this.props.serializeLicenses,
-                            })}
-                          />
-                        </ResultsLoader>
-                      </Grid.Column>
-                    </Grid.Row>
-                  </Grid>
-                </ReactSearchKit>
-              </OverridableContext.Provider>
-            )}
-            {this.props.mode === ModalTypes.CUSTOM && (
-              <Form>
-                <TextField
-                  label={i18next.t('Title')}
-                  placeholder={i18next.t('License title')}
-                  fieldPath="selectedLicense.title"
-                  required
-                />
-                <TextAreaField
-                  fieldPath={'selectedLicense.description'}
-                  label={i18next.t('Description')}
-                />
-                <TextField
-                  label={i18next.t('Link')}
-                  placeholder={i18next.t('License link')}
-                  fieldPath="selectedLicense.link"
-                />
-              </Form>
-            )}
-          </Modal.Content>
-          <Modal.Actions>
-            <ActionButton
-              name="cancel"
-              onClick={(values, formikBag) => {
-                formikBag.resetForm();
-                this.closeModal();
-              }}
-              icon="remove"
-              labelPosition="left"
-              content={i18next.t('Cancel')}
-              floated="left"
-            />
-            <ActionButton
-              name="submit"
-              onClick={(event, formik) => formik.handleSubmit(event)}
-              primary
-              icon="checkmark"
-              labelPosition="left"
-              content={
-                this.props.action === ModalActions.ADD
-                  ? i18next.t('Add license')
-                  : i18next.t('Change license')
-              }
-            />
-          </Modal.Actions>
-        </Modal>
+                        </Grid.Column>
+                        <Grid.Column
+                          width={8}
+                          textAlign="right"
+                          floated="right"
+                        >
+                          <Menu compact>
+                            <Toggle
+                              title={i18next.t('Recommended')}
+                              label="recommended"
+                              filterValue={['tags', 'recommended']}
+                            />
+                            <Toggle
+                              title={i18next.t('All')}
+                              label="all"
+                              filterValue={['tags', 'all']}
+                            />
+                            <Toggle
+                              title={i18next.t('Data')}
+                              label="data"
+                              filterValue={['tags', 'data']}
+                            />
+                            <Toggle
+                              title={i18next.t('Software')}
+                              label="software"
+                              filterValue={['tags', 'software']}
+                            />
+                          </Menu>
+                        </Grid.Column>
+                      </Grid.Row>
+                      <Grid.Row verticalAlign="middle">
+                        <Grid.Column>
+                          <ResultsLoader>
+                            <EmptyResults />
+                            <Error />
+                            <LicenseResults
+                              {...(this.props.serializeLicenses && {
+                                serializeLicenses: this.props.serializeLicenses,
+                              })}
+                            />
+                          </ResultsLoader>
+                        </Grid.Column>
+                      </Grid.Row>
+                    </Grid>
+                  </ReactSearchKit>
+                </OverridableContext.Provider>
+              )}
+              {this.props.mode === ModalTypes.CUSTOM && (
+                <Form>
+                  <TextField
+                    label={i18next.t('Title')}
+                    placeholder={i18next.t('License title')}
+                    fieldPath="selectedLicense.title"
+                    required
+                  />
+                  <TextAreaField
+                    fieldPath={'selectedLicense.description'}
+                    label={i18next.t('Description')}
+                  />
+                  <TextField
+                    label={i18next.t('Link')}
+                    placeholder={i18next.t('License link')}
+                    fieldPath="selectedLicense.link"
+                  />
+                </Form>
+              )}
+            </Modal.Content>
+            <Modal.Actions>
+              <Button
+                name="cancel"
+                onClick={() => {
+                  resetForm();
+                  this.closeModal();
+                }}
+                icon="remove"
+                labelPosition="left"
+                content={i18next.t('Cancel')}
+                floated="left"
+              />
+              <Button
+                name="submit"
+                onClick={(event) => handleSubmit(event)}
+                primary
+                icon="checkmark"
+                labelPosition="left"
+                content={
+                  this.props.action === ModalActions.ADD
+                    ? i18next.t('Add license')
+                    : i18next.t('Change license')
+                }
+              />
+            </Modal.Actions>
+          </Modal>
+        )}
       </Formik>
     );
   }

--- a/src/lib/components/PreviewButton.js
+++ b/src/lib/components/PreviewButton.js
@@ -7,46 +7,41 @@
 
 import { i18next } from '@translations/i18next';
 import React, { Component } from 'react';
-import { ActionButton } from 'react-invenio-forms';
 import { connect } from 'react-redux';
-import { Icon } from 'semantic-ui-react';
+import { connect as connectFormik } from 'formik';
 import {
   DepositFormSubmitActions,
   DepositFormSubmitContext,
 } from '../DepositFormSubmitContext';
 import { DRAFT_PREVIEW_STARTED } from '../state/types';
+import { Button } from 'semantic-ui-react';
+import _omit from 'lodash/omit';
 
 export class PreviewButtonComponent extends Component {
   static contextType = DepositFormSubmitContext;
 
-  handlePreview = (event, formik) => {
+  handlePreview = (event, handleSubmit) => {
     this.context.setSubmitContext(DepositFormSubmitActions.PREVIEW);
-    formik.handleSubmit(event);
+    handleSubmit(event);
   };
 
   render() {
-    const { record, actionState, ...uiProps } = this.props;
+    const { record, actionState, formik, ...ui } = this.props;
+    const { handleSubmit, isSubmitting } = formik;
+
+    const uiProps = _omit(ui, ['dispatch']);
 
     return (
-      <ActionButton
+      <Button
         name="preview"
-        isDisabled={(formik) => formik.isSubmitting}
-        onClick={this.handlePreview}
-        icon
+        disabled={isSubmitting}
+        onClick={(e) => this.handlePreview(e, handleSubmit)}
+        loading={isSubmitting && actionState === DRAFT_PREVIEW_STARTED}
+        icon="eye"
         labelPosition="left"
+        content={i18next.t('Preview')}
         {...uiProps}
-      >
-        {(formik) => (
-          <>
-            {formik.isSubmitting && actionState === DRAFT_PREVIEW_STARTED ? (
-              <Icon size="large" loading name="spinner" />
-            ) : (
-              <Icon name="eye" />
-            )}
-            {i18next.t('Preview')}
-          </>
-        )}
-      </ActionButton>
+      />
     );
   }
 }
@@ -59,4 +54,4 @@ const mapStateToProps = (state) => ({
 export const PreviewButton = connect(
   mapStateToProps,
   null
-)(PreviewButtonComponent);
+)(connectFormik(PreviewButtonComponent));

--- a/src/lib/components/PublishButton/SubmitReviewModal.js
+++ b/src/lib/components/PublishButton/SubmitReviewModal.js
@@ -11,7 +11,6 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { Trans } from 'react-i18next';
 import {
-  ActionButton,
   ErrorLabel,
   RadioField,
   TextAreaField,
@@ -58,7 +57,7 @@ export class SubmitReviewModal extends Component {
         validateOnChange={false}
         validateOnBlur={false}
       >
-        {({ values, errors, touched }) => {
+        {({ values, resetForm, handleSubmit }) => {
           return (
             <Modal
               open={isConfirmModalOpen}
@@ -151,10 +150,10 @@ export class SubmitReviewModal extends Component {
                 <Button onClick={onClose} floated="left">
                   {i18next.t('Cancel')}
                 </Button>
-                <ActionButton
+                <Button
                   name="submitReview"
-                  onClick={(event, formik) => {
-                    formik.handleSubmit(event);
+                  onClick={(event) => {
+                    handleSubmit(event);
                   }}
                   positive
                   content={i18next.t('Submit review')}

--- a/src/lib/components/SaveButton.js
+++ b/src/lib/components/SaveButton.js
@@ -8,48 +8,46 @@
 
 import { i18next } from '@translations/i18next';
 import React, { Component } from 'react';
-import { ActionButton } from 'react-invenio-forms';
 import { connect } from 'react-redux';
-import { Icon } from 'semantic-ui-react';
+import { Button } from 'semantic-ui-react';
 import {
   DepositFormSubmitActions,
   DepositFormSubmitContext,
 } from '../DepositFormSubmitContext';
 import { DRAFT_SAVE_STARTED } from '../state/types';
 import { scrollTop } from '../utils';
+import _omit from 'lodash/omit';
+import { connect as connectFormik } from 'formik';
 
 export class SaveButtonComponent extends Component {
   static contextType = DepositFormSubmitContext;
 
-  handleSave = (event, formik) => {
+  handleSave = (event) => {
+    const { formik } = this.props;
+    const { handleSubmit } = formik;
+
     this.context.setSubmitContext(DepositFormSubmitActions.SAVE);
-    formik.handleSubmit(event);
+    handleSubmit(event);
     scrollTop();
   };
 
   render() {
-    const { actionState, ...uiProps } = this.props;
+    const { actionState, formik, ...ui } = this.props;
+    const { isSubmitting } = formik;
+
+    const uiProps = _omit(ui, ['dispatch']);
 
     return (
-      <ActionButton
-        isDisabled={(formik) => formik.isSubmitting}
+      <Button
         name="save"
-        onClick={this.handleSave}
-        icon
+        disabled={isSubmitting}
+        onClick={(event) => this.handleSave(event)}
+        icon="save"
+        loading={isSubmitting && actionState === DRAFT_SAVE_STARTED}
         labelPosition="left"
+        content={i18next.t('Save draft')}
         {...uiProps}
-      >
-        {(formik) => (
-          <>
-            {formik.isSubmitting && actionState === DRAFT_SAVE_STARTED ? (
-              <Icon size="large" loading name="spinner" />
-            ) : (
-              <Icon name="save" />
-            )}
-            {i18next.t('Save draft')}
-          </>
-        )}
-      </ActionButton>
+      />
     );
   }
 }
@@ -58,4 +56,7 @@ const mapStateToProps = (state) => ({
   actionState: state.deposit.actionState,
 });
 
-export const SaveButton = connect(mapStateToProps, null)(SaveButtonComponent);
+export const SaveButton = connect(
+  mapStateToProps,
+  null
+)(connectFormik(SaveButtonComponent));


### PR DESCRIPTION
Refactored the action button and all dependent components to not use the ActionButton component, instead they all now use a normal SUI button component, to keep the interface clear.

needs  https://github.com/inveniosoftware/react-invenio-forms/pull/138


buttons after changes (should be the same):


![Screenshot from 2022-06-09 09-47-58](https://user-images.githubusercontent.com/55200060/172793755-0f141d51-bfc2-4c2e-9823-5cb65497e1e1.png)
![Screenshot from 2022-06-09 09-47-52](https://user-images.githubusercontent.com/55200060/172793761-d1487fbb-1eff-4533-8fc1-d73418405ba2.png)
![Screenshot from 2022-06-09 09-47-47](https://user-images.githubusercontent.com/55200060/172793763-008cf1c1-d87c-408d-a6b8-6eb9631bea3d.png)
![Screenshot from 2022-06-09 09-47-42](https://user-images.githubusercontent.com/55200060/172793766-2186a35b-e32e-4e57-bbcf-4b49d633d989.png)


