### PR TITLE
files: added string normalization for filenames comparison.

### DIFF
--- a/src/lib/DepositFilesService.js
+++ b/src/lib/DepositFilesService.js
@@ -113,7 +113,7 @@ export class RDMDepositFilesService extends DepositFilesService {
 
     // get the init file with the sent filename
     const initializedFile = response.data.entries.filter(
-      (entry) => entry.key === file.name
+      (entry) => entry.key.normalize() === file.name.normalize()
     )[0]; // this should throw an error if not found
 
     return initializedFile;

--- a/src/lib/state/reducers/files.js
+++ b/src/lib/state/reducers/files.js
@@ -32,15 +32,17 @@ const initialState = {};
 
 const fileReducer = (state = initialState, action) => {
   let newState;
+  // Filename needs to be normalised due to encoding differences between client and server.
+  const remoteFileName = action.payload?.filename?.normalize() ?? '';
   switch (action.type) {
     case FILE_UPLOAD_ADDED:
       return {
         ...state,
         entries: {
           ...state.entries,
-          [action.payload.filename]: {
+          [remoteFileName]: {
             progressPercentage: 0,
-            name: action.payload.filename,
+            name: remoteFileName,
             size: 0,
             status: UploadState.pending,
             checksum: null,
@@ -55,8 +57,8 @@ const fileReducer = (state = initialState, action) => {
         ...state,
         entries: {
           ...state.entries,
-          [action.payload.filename]: {
-            ...state.entries[action.payload.filename],
+          [remoteFileName]: {
+            ...state.entries[remoteFileName],
             progressPercentage: action.payload.percent,
             status: UploadState.uploading,
           },
@@ -69,8 +71,8 @@ const fileReducer = (state = initialState, action) => {
         ...state,
         entries: {
           ...state.entries,
-          [action.payload.filename]: {
-            ...state.entries[action.payload.filename],
+          [remoteFileName]: {
+            ...state.entries[remoteFileName],
             status: UploadState.finished,
             size: action.payload.size,
             progressPercentage: 100,
@@ -98,8 +100,8 @@ const fileReducer = (state = initialState, action) => {
         ...state,
         entries: {
           ...state.entries,
-          [action.payload.filename]: {
-            ...state.entries[action.payload.filename],
+          [remoteFileName]: {
+            ...state.entries[remoteFileName],
             status: UploadState.error,
             cancelUploadFn: null,
           },
@@ -117,8 +119,8 @@ const fileReducer = (state = initialState, action) => {
         ...state,
         entries: {
           ...state.entries,
-          [action.payload.filename]: {
-            ...state.entries[action.payload.filename],
+          [remoteFileName]: {
+            ...state.entries[remoteFileName],
             cancelUploadFn: action.payload.cancelUploadFn,
           },
         },
@@ -126,7 +128,7 @@ const fileReducer = (state = initialState, action) => {
       };
     case FILE_UPLOAD_CANCELLED:
       const {
-        [action.payload.filename]: cancelledFile,
+        [remoteFileName]: cancelledFile,
         ...afterCancellationEntriesState
       } = state.entries;
       return {
@@ -141,7 +143,7 @@ const fileReducer = (state = initialState, action) => {
       };
     case FILE_DELETED_SUCCESS:
       const {
-        [action.payload.filename]: deletedFile,
+        [remoteFileName]: deletedFile,
         ...afterDeletionEntriesState
       } = state.entries;
       return {


### PR DESCRIPTION
closes https://github.com/inveniosoftware/invenio-app-rdm/issues/1744

The issue here boils down on how client and server deal with special characters for file names. E.g. the character á can be encoded as a single unicode character (á) or as a composite character (a ´). 

Therefore: 

- when comparing filenames between server and client, string normalisation is needed.
- when the server sends an event (e.g. `FILE_UPLOAD_CANCELLED`) to the client, the filename's string must be normalised as well. Otherwise, `state.entries` will index files by name and there will be a mismatch again and  two "files" are going to be added to `state.entries`.  

Note: this is a quick fix for this issue. Ideally we should be consistent with the encoding. In my opinion, the client should adapt to the server and not the other way around. Nonetheless, the file creation is handled by HTML5 / javascript and the created `File` object has the property `name` as `read-only` (see js [documentation](https://w3c.github.io/FileAPI/#dfn-name) for files). I tried changing the html page encoding but it did not fix the issue. 