### PR TITLE
utils: exporting humanReadableBytes function

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+Version 0.19.14 (released 2022-07-05)
+
+* utils: exports function humanReadableBytes to be used outside react-invenio-deposit.
+* creatibutors: fixed dropdown off-screen rendering
+
 Version 0.19.13 (released 2022-07-01)
 
 * fix community header margins on mobile view

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-invenio-deposit",
-  "version": "0.19.13",
+  "version": "0.19.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-invenio-deposit",
-  "version": "0.19.13",
+  "version": "0.19.14",
   "description": "React components to build forms in Invenio",
   "main": "dist/cjs/index.js",
   "browser": "dist/cjs/index.js",

--- a/src/lib/components/FileUploader/index.js
+++ b/src/lib/components/FileUploader/index.js
@@ -39,3 +39,5 @@ export const FileUploader = connect(
   mapStateToProps,
   mapDispatchToProps
 )(FileUploaderComponent);
+
+export { humanReadableBytes } from "./utils";

--- a/src/lib/components/index.js
+++ b/src/lib/components/index.js
@@ -17,7 +17,7 @@ export { DeleteButton } from './DeleteButton';
 export { DepositFormTitle } from './DepositFormTitle';
 export { DepositStatusBox } from './DepositStatus';
 export { DescriptionsField } from './DescriptionsField';
-export { FileUploader } from './FileUploader';
+export { FileUploader, humanReadableBytes } from './FileUploader';
 export { FormFeedback } from './FormFeedback';
 export { FundingField } from './Funding';
 export { IdentifiersField, PIDField } from './Identifiers';


### PR DESCRIPTION
closes https://github.com/inveniosoftware/invenio-app-rdm/issues/1716

- Exports `humanReadableBytes` to be used outside `react-invenio-deposit`.