### PR TITLE
Put semver.org link between parenthesis

### DIFF
--- a/src/lib/components/VersionField.js
+++ b/src/lib/components/VersionField.js
@@ -19,7 +19,7 @@ export class VersionField extends Component {
       <span>
         <Trans>
           Mostly relevant for software and dataset uploads. A semantic version
-          string is preferred see
+          string is preferred (see
           <a
             href="https://semver.org/"
             target="_blank"
@@ -28,7 +28,7 @@ export class VersionField extends Component {
             {' '}
             semver.org
           </a>
-          , but any version string is accepted.
+          ) but any version string is accepted.
         </Trans>
       </span>
     );


### PR DESCRIPTION
The help text for the version string is currently a bit strange to read:

```
Mostly relevant for software and dataset uploads. A semantic version string is preferred see [semver.org](https://semver.org/), but any version string is accepted.
```

This PR just puts the semver.org link between parenthesis so it's easier to follow the sense of the phrase.