### PR TITLE
Allow customization of the deposit modal

### DIFF
--- a/src/lib/components/PublishButton/PublishButton.js
+++ b/src/lib/components/PublishButton/PublishButton.js
@@ -53,6 +53,7 @@ class PublishButtonComponent extends Component {
       buttonLabel,
       publishWithoutCommunity,
       formik,
+      publishModalExtraContent,
       ...ui
     } = this.props;
     const { isConfirmModalOpen } = this.state;
@@ -72,6 +73,7 @@ class PublishButtonComponent extends Component {
           labelPosition="left"
           content={buttonLabel}
           {...uiProps}
+          type="button" // needed so the formik form doesn't handle it as submit button i.e enable HTML validation on required input fields
         />
         {isConfirmModalOpen && (
           <Modal
@@ -94,6 +96,9 @@ class PublishButtonComponent extends Component {
                   )}
                 </p>
               </Message>
+              {publishModalExtraContent && (
+                <div dangerouslySetInnerHTML={{ __html: publishModalExtraContent }} />
+              )}
             </Modal.Content>
             <Modal.Actions>
               <Button onClick={this.closeConfirmModal} floated="left">
@@ -120,17 +125,20 @@ PublishButtonComponent.propTypes = {
   actionState: PropTypes.string,
   numberOfFiles: PropTypes.number.isRequired,
   formik: PropTypes.object.isRequired,
+  publishModalExtraContent: PropTypes.string,
 };
 
 PublishButtonComponent.defaultProps = {
   buttonLabel: i18next.t("Publish"),
   publishWithoutCommunity: false,
   actionState: undefined,
+  publishModalExtraContent: undefined,
 };
 
 const mapStateToProps = (state) => ({
   actionState: state.deposit.actionState,
   numberOfFiles: Object.values(state.files.entries).length,
+  publishModalExtraContent: state.deposit.config.publish_modal_extra,
 });
 
 export const PublishButton = connect(

--- a/src/lib/components/PublishButton/SubmitReviewButton.js
+++ b/src/lib/components/PublishButton/SubmitReviewButton.js
@@ -58,6 +58,7 @@ class SubmitReviewButtonComponent extends Component {
       disableSubmitForReviewButton,
       isRecordSubmittedForReview,
       formik,
+      publishModalExtraContent,
       ...ui
     } = this.props;
 
@@ -83,6 +84,7 @@ class SubmitReviewButtonComponent extends Component {
               : i18next.t("Submit for review")
           }
           {...uiProps}
+          type="button" // needed so the formik form doesn't handle it as submit button i.e enable HTML validation on required input fields
         />
         {isConfirmModalOpen && (
           <SubmitReviewModal
@@ -91,6 +93,7 @@ class SubmitReviewButtonComponent extends Component {
             onSubmit={this.handleSubmitReview}
             community={community}
             onClose={this.closeConfirmModal}
+            publishModalExtraContent={publishModalExtraContent}
           />
         )}
       </>
@@ -106,11 +109,13 @@ SubmitReviewButtonComponent.propTypes = {
   disableSubmitForReviewButton: PropTypes.bool,
   isRecordSubmittedForReview: PropTypes.bool.isRequired,
   formik: PropTypes.object.isRequired,
+  publishModalExtraContent: PropTypes.string,
 };
 
 SubmitReviewButtonComponent.defaultProps = {
   numberOfFiles: undefined,
   disableSubmitForReviewButton: undefined,
+  publishModalExtraContent: undefined,
 };
 
 const mapStateToProps = (state) => ({
@@ -121,6 +126,7 @@ const mapStateToProps = (state) => ({
   disableSubmitForReviewButton:
     state.deposit.editorState.ui.disableSubmitForReviewButton,
   numberOfFiles: Object.values(state.files.entries).length,
+  publishModalExtraContent: state.deposit.config.publish_modal_extra,
 });
 
 export const SubmitReviewButton = connect(

--- a/src/lib/components/PublishButton/SubmitReviewModal.js
+++ b/src/lib/components/PublishButton/SubmitReviewModal.js
@@ -22,8 +22,14 @@ export class SubmitReviewModal extends Component {
   });
 
   render() {
-    const { initialReviewComment, isConfirmModalOpen, community, onClose, onSubmit } =
-      this.props;
+    const {
+      initialReviewComment,
+      isConfirmModalOpen,
+      community,
+      onClose,
+      onSubmit,
+      publishModalExtraContent,
+    } = this.props;
     const communityTitle = community.metadata.title;
     return (
       <Formik
@@ -120,6 +126,11 @@ export class SubmitReviewModal extends Component {
                     fieldPath="reviewComment"
                     label="Message to curators (optional)"
                   />
+                  {publishModalExtraContent && (
+                    <div
+                      dangerouslySetInnerHTML={{ __html: publishModalExtraContent }}
+                    />
+                  )}
                 </Form>
               </Modal.Content>
               <Modal.Actions>
@@ -149,8 +160,10 @@ SubmitReviewModal.propTypes = {
   onClose: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,
   initialReviewComment: PropTypes.string,
+  publishModalExtraContent: PropTypes.string,
 };
 
 SubmitReviewModal.defaultProps = {
   initialReviewComment: "",
+  publishModalExtraContent: "",
 };

--- a/src/lib/components/PublishButton/SubmitReviewOrPublishButton.js
+++ b/src/lib/components/PublishButton/SubmitReviewOrPublishButton.js
@@ -24,28 +24,33 @@ class SubmitReviewOrPublishComponent extends Component {
       ...ui
     } = this.props;
 
-    return showSubmitForReviewButton ? (
-      <SubmitReviewButton {...ui} />
-    ) : showChangeCommunityButton ? (
-      <>
-        <CommunitySelectionModal
-          onCommunityChange={(community) => {
-            changeSelectedCommunity(community);
-          }}
-          chosenCommunity={community}
-          trigger={
-            <Button content={i18next.t("Change community")} fluid className="mb-10" />
-          }
-        />
-        <PublishButton
-          buttonLabel={i18next.t("Publish without community")}
-          publishWithoutCommunity
-          {...ui}
-        />
-      </>
-    ) : (
-      <PublishButton {...ui} />
-    );
+    let result;
+
+    if (showSubmitForReviewButton) {
+      result = <SubmitReviewButton {...ui} />;
+    } else if (showChangeCommunityButton) {
+      result = (
+        <>
+          <CommunitySelectionModal
+            onCommunityChange={(community) => {
+              changeSelectedCommunity(community);
+            }}
+            chosenCommunity={community}
+            trigger={
+              <Button content={i18next.t("Change community")} fluid className="mb-10" />
+            }
+          />
+          <PublishButton
+            buttonLabel={i18next.t("Publish without community")}
+            publishWithoutCommunity
+            {...ui}
+          />
+        </>
+      );
+    } else {
+      result = <PublishButton {...ui} />;
+    }
+    return result;
   }
 }
 


### PR DESCRIPTION
- part of closing https://github.com/inveniosoftware/invenio-app-rdm/issues/1204
- Integration in app-rdm: https://github.com/inveniosoftware/invenio-app-rdm/pull/1832
- The implementation goes for just injecting html directly which is fine since the html comes from the config.
- The thing left is for the community publish modal text to be added.
