### PR TITLE
feedback: show custom fields errors

### DIFF
--- a/src/lib/components/FormFeedback.js
+++ b/src/lib/components/FormFeedback.js
@@ -209,8 +209,20 @@ class DisconnectedFormFeedback extends Component {
           return ['pids.' + key, value];
         })
       : [['pids', pids]];
+
+    const custom_fields = errors.custom_fields || {};
+    const step0_custom_fields = Object.entries(custom_fields).map(
+      ([key, value]) => {
+        return ['custom_fields.' + key, value];
+      }
+    );
+
     const step0 = Object.fromEntries(
-      step0_metadata.concat(step0_files).concat(step0_access).concat(step0_pids)
+      step0_metadata
+        .concat(step0_files)
+        .concat(step0_access)
+        .concat(step0_pids)
+        .concat(step0_custom_fields)
     );
 
     // Step 1 - Transform each error value into array of error messages


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Please describe briefly your pull request.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code).
- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
