### PR TITLE
Pass editor config to additional description fields

### DIFF
--- a/src/lib/components/AdditionalDescriptionsField.js
+++ b/src/lib/components/AdditionalDescriptionsField.js
@@ -1,7 +1,8 @@
 // This file is part of React-Invenio-Deposit
-// Copyright (C) 2020 CERN.
+// Copyright (C) 2020      CERN.
 // Copyright (C) 2020-2022 Northwestern University.
-// Copyright (C) 2021 Graz University of Technology.
+// Copyright (C) 2021      Graz University of Technology.
+// Copyright (C) 2022      TU Wien.
 //
 // React-Invenio-Deposit is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
@@ -18,7 +19,7 @@ import { sortOptions } from "../utils";
 
 export class AdditionalDescriptionsField extends Component {
   render() {
-    const { fieldPath, options, recordUI } = this.props;
+    const { fieldPath, options, recordUI, editorConfig } = this.props;
     return (
       <ArrayField
         addButtonLabel={i18next.t("Add description")}
@@ -36,6 +37,7 @@ export class AdditionalDescriptionsField extends Component {
                   <RichInputField
                     fieldPath={`${fieldPathPrefix}.description`}
                     label={i18next.t("Additional Description")}
+                    editorConfig={editorConfig}
                     optimized
                     required
                   />
@@ -109,8 +111,10 @@ AdditionalDescriptionsField.propTypes = {
     ),
   }).isRequired,
   recordUI: PropTypes.object,
+  editorConfig: PropTypes.object,
 };
 
 AdditionalDescriptionsField.defaultProps = {
   recordUI: {},
+  editorConfig: undefined,
 };

--- a/src/lib/components/DescriptionsField.js
+++ b/src/lib/components/DescriptionsField.js
@@ -28,6 +28,7 @@ export class DescriptionsField extends Component {
         <AdditionalDescriptionsField
           recordUI={recordUI}
           options={options}
+          editorConfig={editorConfig}
           fieldPath="metadata.additional_descriptions"
         />
       </>


### PR DESCRIPTION
# The issue and proposed solution

In the deposit page, we restricted the formatting options for the **descriptions** field by specifying which plugins to *not load* in the `editorConfig`.
However, this was only used in the main **descriptions** input field but never passed to the **additional descriptions** input fields, leading to inconsistency regarding which formatting options are available.
Further, the additionally available formatting in the additional descriptions usually gets `bleach`'d out anyway.
This PR fixes that oversight, to make the input fields aligned.

## Before

![image](https://user-images.githubusercontent.com/6437519/201321132-2de8a098-a82d-4eac-832c-ea71105c5255.png)

## After

![image](https://user-images.githubusercontent.com/6437519/201320821-fd47d0e5-dd61-4205-9286-3581427b54d5.png)

Note that the icons aren't displayed in the second screenshot, because I only quickly set up a `my-site` for testing.
The first screenshot is from https://inveniordm.web.cern.ch/.