### PR TITLE
AccessRightField, FileUploaderToolbar: Add conditionals based on config

### DIFF
--- a/src/lib/components/AccessRightField.js
+++ b/src/lib/components/AccessRightField.js
@@ -24,6 +24,7 @@ export class AccessRightFieldCmp extends Component {
       label,
       labelIcon,
       community,
+      canEditFullRecordVisibility,
     } = this.props;
 
     const communityAccess = community?.access.visibility || "public";
@@ -38,12 +39,16 @@ export class AccessRightFieldCmp extends Component {
             </Card.Header>
           </Card.Content>
           <Card.Content>
-            <MetadataAccess
-              recordAccess={formik.field.value.record}
-              communityAccess={communityAccess}
-            />
+            {canEditFullRecordVisibility && (
+              <>
+                <MetadataAccess
+                  recordAccess={formik.field.value.record}
+                  communityAccess={communityAccess}
+                />
 
-            <Divider hidden />
+                <Divider hidden />
+              </>
+            )}
 
             <FilesAccess
               access={formik.field.value}
@@ -84,15 +89,18 @@ AccessRightFieldCmp.propTypes = {
   formik: PropTypes.object.isRequired,
   label: PropTypes.string.isRequired,
   labelIcon: PropTypes.string.isRequired,
+  canEditFullRecordVisibility: PropTypes.bool,
   community: PropTypes.object,
 };
 
 AccessRightFieldCmp.defaultProps = {
   community: undefined,
+  canEditFullRecordVisibility: true,
 };
 
 const mapStateToPropsAccessRightFieldCmp = (state) => ({
   community: state.deposit.editorState.selectedCommunity,
+  canEditFullRecordVisibility: state.deposit.config.can_edit_full_record_visibility,
 });
 
 export const AccessRightFieldComponent = connect(

--- a/src/lib/components/FileUploader/FileUploaderToolbar.js
+++ b/src/lib/components/FileUploader/FileUploaderToolbar.js
@@ -39,7 +39,7 @@ export const FileUploaderToolbar = ({
         tablet={6}
         computer={6}
       >
-        {config.canHaveMetadataOnlyRecords && (
+        {config.require_files || (
           <List horizontal>
             <List.Item>
               <Checkbox


### PR DESCRIPTION
Closes https://github.com/zenodo/zenodo-rdm/issues/46

- Enables disabling of the metadata-only option in the UI
- Enables disabling of the full record visibility option in the UI

Screenshot of disabling: https://github.com/zenodo/zenodo-rdm/pull/90