### PR TITLE
utils: refactored function to return a string instead of jsx.

### DIFF
--- a/src/lib/components/FileUploader/utils.js
+++ b/src/lib/components/FileUploader/utils.js
@@ -6,8 +6,6 @@
 // React-Invenio-Deposit is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
 
-import React from "react";
-
 import _isNumber from "lodash/isNumber";
 
 export function humanReadableBytes(bytes, decimalDisplay = false) {
@@ -18,25 +16,13 @@ export function humanReadableBytes(bytes, decimalDisplay = false) {
     const gigaBytes = base * megaBytes;
 
     if (bytes < kiloBytes) {
-      return <>{bytes} bytes</>;
+      return `${bytes} bytes`;
     } else if (bytes < megaBytes) {
-      return (
-        <>
-          {(bytes / kiloBytes).toFixed(2)} {decimalDisplay ? "KB" : "KiB"}
-        </>
-      );
+      return `${(bytes / kiloBytes).toFixed(2)} ${decimalDisplay ? "KB" : "KiB"}`;
     } else if (bytes < gigaBytes) {
-      return (
-        <>
-          {(bytes / megaBytes).toFixed(2)} {decimalDisplay ? "MB" : "MiB"}
-        </>
-      );
+      return `${(bytes / megaBytes).toFixed(2)} ${decimalDisplay ? "MB" : "MiB"}`;
     } else {
-      return (
-        <>
-          {(bytes / gigaBytes).toFixed(2)} {decimalDisplay ? "GB" : "GiB"}
-        </>
-      );
+      return `${(bytes / gigaBytes).toFixed(2)} ${decimalDisplay ? "GB" : "GiB"}`;
     }
   }
   return "";


### PR DESCRIPTION
function `humanReadableBytes` returns a string instead of JSX.

By returning `jsx` , its usage in strings (e.g. templating) was more difficult. See this [discussion](https://github.com/zenodo/zenodo-rdm/pull/89#discussion_r1022771525) for more details