### PR TITLE
components: Add overridable to metadata-only button and metadata access

### DIFF
--- a/src/lib/components/Access/MetadataAccess.js
+++ b/src/lib/components/Access/MetadataAccess.js
@@ -2,20 +2,24 @@ import React from "react";
 import PropTypes from "prop-types";
 import { ProtectionButtons } from "./ProtectionButtons";
 import { i18next } from "@translations/i18next";
+import Overridable from "react-overridable";
 
-export const MetadataAccess = ({ recordAccess, communityAccess }) => {
+export const MetadataAccess = (props) => {
+  const { recordAccess, communityAccess } = props;
   const publicMetadata = recordAccess === "public";
   const publicCommunity = communityAccess === "public";
 
   return (
-    <>
-      {i18next.t("Full record")}
-      <ProtectionButtons
-        active={publicMetadata && publicCommunity}
-        disabled={!publicCommunity}
-        fieldPath="access.record"
-      />
-    </>
+    <Overridable id="ReactInvenioDeposit.MetadataAccess.layout" {...props}>
+      <>
+        {i18next.t("Full record")}
+        <ProtectionButtons
+          active={publicMetadata && publicCommunity}
+          disabled={!publicCommunity}
+          fieldPath="access.record"
+        />
+      </>
+    </Overridable>
   );
 };
 

--- a/src/lib/components/FileUploader/FileUploaderToolbar.js
+++ b/src/lib/components/FileUploader/FileUploaderToolbar.js
@@ -12,17 +12,13 @@ import { Header, Checkbox, Grid, Icon, Label, List, Popup } from "semantic-ui-re
 import { humanReadableBytes } from "./utils";
 import { i18next } from "@translations/i18next";
 import PropTypes from "prop-types";
+import Overridable from "react-overridable";
 
 // NOTE: This component has to be a function component to allow
 //       the `useFormikContext` hook.
-export const FileUploaderToolbar = ({
-  config,
-  filesList,
-  filesSize,
-  filesEnabled,
-  quota,
-  decimalSizeDisplay,
-}) => {
+export const FileUploaderToolbar = (props) => {
+  const { config, filesList, filesSize, filesEnabled, quota, decimalSizeDisplay } =
+    props;
   const { setFieldValue } = useFormikContext();
 
   const handleOnChangeMetadataOnly = () => {
@@ -40,23 +36,25 @@ export const FileUploaderToolbar = ({
         computer={6}
       >
         {config.canHaveMetadataOnlyRecords && (
-          <List horizontal>
-            <List.Item>
-              <Checkbox
-                label={i18next.t("Metadata-only record")}
-                onChange={handleOnChangeMetadataOnly}
-                disabled={filesList.length > 0}
-                checked={!filesEnabled}
-              />
-            </List.Item>
-            <List.Item>
-              <Popup
-                trigger={<Icon name="question circle outline" className="neutral" />}
-                content={i18next.t("Disable files for this record")}
-                position="top center"
-              />
-            </List.Item>
-          </List>
+          <Overridable id="ReactInvenioDeposit.MetadataOnlyToggle.layout" {...props}>
+            <List horizontal>
+              <List.Item>
+                <Checkbox
+                  label={i18next.t("Metadata-only record")}
+                  onChange={handleOnChangeMetadataOnly}
+                  disabled={filesList.length > 0}
+                  checked={!filesEnabled}
+                />
+              </List.Item>
+              <List.Item>
+                <Popup
+                  trigger={<Icon name="question circle outline" className="neutral" />}
+                  content={i18next.t("Disable files for this record")}
+                  position="top center"
+                />
+              </List.Item>
+            </List>
+          </Overridable>
         )}
       </Grid.Column>
       {filesEnabled && (


### PR DESCRIPTION
Closes https://github.com/zenodo/zenodo-rdm/issues/46

Adds `<Overridable />` to `<MetadataAccess />` and metadata-only toggle button in `<FileUploaderToolbar />`

Needs https://github.com/inveniosoftware/invenio-app-rdm/pull/1970