### PR TITLE
SubjectsField: update default label to align with record page

### DIFF
--- a/src/lib/components/SubjectsField.js
+++ b/src/lib/components/SubjectsField.js
@@ -130,7 +130,7 @@ SubjectsField.propTypes = {
 
 SubjectsField.defaultProps = {
   required: false,
-  label: i18next.t("Subjects"),
+  label: i18next.t("Keywords and subjects"),
   labelIcon: "tag",
   multiple: true,
   clearable: true,


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/2148

This PR updates the "Subjects" title to "Keywords and subjects" to align with the published record page.

## Screenshot
![Screenshot 2023-03-20 at 13 47 55](https://user-images.githubusercontent.com/21052053/226343798-e1d615d8-b7c3-4a0b-a4f0-e1c2e918f369.png)
