### PR TITLE
CustomField: Add a recursiveMapping function that fixes key errors wi…

### DIFF
--- a/src/lib/fields/CustomField.js
+++ b/src/lib/fields/CustomField.js
@@ -9,6 +9,7 @@ import _get from "lodash/get";
 import _set from "lodash/set";
 import _cloneDeep from "lodash/cloneDeep";
 import _isArray from "lodash/isArray";
+import _isObject from "lodash/isObject";
 import { Field } from "./Field";
 
 export class CustomField extends Field {
@@ -23,13 +24,24 @@ export class CustomField extends Field {
     this.vocabularyFields = vocabularyFields;
   }
 
+  recursiveMapping(value, isVocabularyField, mapValue) {
+    // Since Arrays are a subset of Objects, if _isArray were the else if, we would never get to that condition.
+    let _value = null;
+    if (_isArray(value))
+      _value = value.map((v, i) => mapValue(v, i, isVocabularyField));
+    else if (_isObject(value) && !isVocabularyField) {
+      for (let key in value)
+        value[key] = this.recursiveMapping(value[key], isVocabularyField, mapValue);
+      _value = value;
+    } else _value = mapValue(value, null, isVocabularyField);
+    return _value;
+  }
+
   #mapCustomFields(record, customFields, mapValue) {
     if (customFields !== null) {
       for (const [key, value] of Object.entries(customFields)) {
         const isVocabularyField = this.vocabularyFields.includes(key);
-        const _value = _isArray(value)
-          ? value.map((v, i) => mapValue(v, i, isVocabularyField))
-          : mapValue(value, null, isVocabularyField);
+        let _value = this.recursiveMapping(value, isVocabularyField, mapValue);
         record = _set(record, `custom_fields.${key}`, _value);
       }
     }


### PR DESCRIPTION
…th CustomFields that have nested Arrays.

:heart: Thank you for your contribution!

### Description

This PR fixes a bug where CustomFields that have nested Arrays fail to publish. This failure is due to the "_key" attribute that does not get removed as part of the serialization.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code).
- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
