### PR TITLE
fix: scehme typo in CreatributorsModal.js

### DIFF
--- a/src/lib/components/Creatibutors/CreatibutorsModal.js
+++ b/src/lib/components/Creatibutors/CreatibutorsModal.js
@@ -208,7 +208,7 @@ export class CreatibutorsModal extends Component {
     } else {
       return (
         <>
-          {identifier.scehme}: {identifier.identifier}
+          {identifier.scheme}: {identifier.identifier}
         </>
       );
     }


### PR DESCRIPTION
If using a non-standard scheme, this typo causes it to be labelled with only an orphaned colon. See #648.

### Description

> Please describe briefly your pull request.

Changes a typo so non-ROR/GND/ORCID identifier schemes for names are labelled properly.


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.
